### PR TITLE
Fixed dyn_var and builder to not use Mixins. Use inheritance instead …

### DIFF
--- a/include/builder/builder_context.h
+++ b/include/builder/builder_context.h
@@ -12,8 +12,6 @@
 namespace builder {
 
 
-//template <typename BT, typename... arg_types>
-//std::vector<block::expr::Ptr> extract_call_arguments_helper(const builder_base<BT> &first_arg, const arg_types &... rest_args);
 
 template <typename T>
 block::expr::Ptr create_foreign_expr(const T t);
@@ -125,13 +123,13 @@ private:
 	std::function<void(void)> internal_stored_lambda;
 
 	static builder_context *current_builder_context;
-	template <typename BT>
-	friend class builder_base;
+
+	friend class builder;
 
 	friend var;
 
-	template <typename T, typename DVT, typename BT>
-	friend class dyn_var_base;
+	template <typename T>
+	friend class dyn_var;
 
 	template <typename T>
 	friend class static_var;
@@ -150,11 +148,8 @@ private:
 	template <typename BT, typename T>
 	friend BT create_foreign_expr_builder(const T t);
 
-	template <typename BT>
-	friend void create_return_stmt(const builder_base<BT> &a);
+	friend void create_return_stmt(const builder &a);
 
-	template <typename BT>
-	friend struct member_base_impl;
 };
 bool get_next_bool_from_context(builder_context *context, block::expr::Ptr);
 tracer::tag get_offset_in_function(void);

--- a/include/builder/dyn_var.h
+++ b/include/builder/dyn_var.h
@@ -11,6 +11,10 @@ public:
 	block::var::Ptr block_var;
 	block::decl_stmt::Ptr block_decl_stmt;
 
+        // Feature to implement members
+        bool is_member = false;
+        var *parent_var;
+
 	static block::type::Ptr create_block_type(void) {
 		// Cannot create block type for abstract class
 		assert(false);
@@ -26,11 +30,19 @@ public:
 
 };
 
-template<typename T, typename MT, typename BT>
-class dyn_var_base: public var, public MT {
-public:
+// Struct to initialize a dyn_var as member;
+struct as_member_of {
+	var *parent_var;
+	std::string member_name; 
+	as_member_of(var* p, std::string n): parent_var(p), member_name(n) {};	
+};
 
-	typedef dyn_var_base<T, MT, BT> my_type;
+template<typename T>
+class dyn_var: public var{
+public:
+	
+	typedef builder BT;
+	typedef dyn_var<T> my_type;
 	typedef BT associated_BT;
 	typedef T stored_type;
 	typedef my_type super;
@@ -40,10 +52,6 @@ public:
 		return ((BT) * this)(args...);
 	}
 
-	// Required for the MT's virtual function if it exists
-	virtual block::expr::Ptr get_parent() const {
-		return ((BT) (*this)).get_parent();
-	}
 	
 	// These three need to be defined inside the class, cannot be defined globally
 	BT operator=(const var &a) { 
@@ -57,12 +65,12 @@ public:
 		return (BT)*this = a;
 	}
 
-	BT operator=(const dyn_var_base<T, MT, BT> &a) {
+	BT operator=(const dyn_var<T> &a) {
 		return (BT) * this = a;
 	}
 
 	template <typename TO>
-	BT operator=(const dyn_var_base<TO, MT, BT> &a) {
+	BT operator=(const dyn_var<TO> &a) {
 		return (BT) * this = a;
 	}
 
@@ -76,9 +84,6 @@ public:
 
 	template <typename Ts>
 	BT operator=(const static_var<Ts> &a) {
-		return operator=((BT)a);
-	}
-	BT operator=(const member_base &a) {
 		return operator=((BT)a);
 	}
 
@@ -115,7 +120,7 @@ public:
 		builder_context::current_builder_context->add_stmt_to_current_block(decl_stmt);
 	}
 	// Basic and other constructors
-	dyn_var_base(const char* name=nullptr) { 
+	dyn_var(const char* name=nullptr) { 
 		if (builder_context::current_builder_context == nullptr) {
 			create_dyn_var(true); 
 			if (name != nullptr) {
@@ -125,7 +130,7 @@ public:
 		} else
 			create_dyn_var(false); 
 	}
-	dyn_var_base(const dyn_var_sentinel_type& a, std::string name = "") {
+	dyn_var(const dyn_var_sentinel_type& a, std::string name = "") {
 		create_dyn_var(true);
 		if (name != "") {
 			block_var->var_name = name;
@@ -133,24 +138,33 @@ public:
 		}
 	
 	}
+        // Constructor to initialize a dyn_var as member
+        // This declaration does not produce a declaration
+        dyn_var(const as_member_of &a) {
+		is_member = true;
+		parent_var = a.parent_var;
+		var_name = a.member_name;            
+		block_var = nullptr;
+		block_decl_stmt = nullptr;
+	}
 	// A very special move constructor that is used to create exact 
 	// replicas of variables
-	dyn_var_base(const dyn_var_consume &a) {
+	dyn_var(const dyn_var_consume &a) {
 		block_var = a.block_var;
 		var_name = block_var->var_name;
 		block_decl_stmt = nullptr;	
 	}
 
-	dyn_var_base(const my_type &a) : my_type((BT)a) {}
+	dyn_var(const my_type &a) : my_type((BT)a) {}
 
 	
 	template <typename TO>
-	dyn_var_base(const dyn_var_base<TO, MT, BT> &a) : my_type((BT)a) {}
+	dyn_var(const dyn_var<TO> &a) : my_type((BT)a) {}
 	
 	template <typename TO>
-	dyn_var_base(const static_var<TO> &a) : my_type((TO)a) {}
+	dyn_var(const static_var<TO> &a) : my_type((TO)a) {}
 
-	dyn_var_base(const BT &a) {
+	dyn_var(const BT &a) {
 		builder_context::current_builder_context->remove_node_from_sequence(a.block_expr);
 		create_dyn_var();
 		if (builder_context::current_builder_context->bool_vector.size() > 0)
@@ -158,13 +172,12 @@ public:
 		block_decl_stmt->init_expr = a.block_expr;
 	}
 
-	dyn_var_base(const int &a) : my_type((BT)a) {}
-	dyn_var_base(const bool &a) : my_type((BT)a) {}
-	dyn_var_base(const double &a) : my_type((BT)a) {}
-	dyn_var_base(const float &a) : my_type((BT)a) {}
-	dyn_var_base(const member_base& a): my_type((BT)a) {}
+	dyn_var(const int &a) : my_type((BT)a) {}
+	dyn_var(const bool &a) : my_type((BT)a) {}
+	dyn_var(const double &a) : my_type((BT)a) {}
+	dyn_var(const float &a) : my_type((BT)a) {}
 
-	dyn_var_base(const std::initializer_list<BT> &_a) {
+	dyn_var(const std::initializer_list<BT> &_a) {
 		std::vector<BT> a(_a);
 
 		assert(builder_context::current_builder_context != nullptr);
@@ -184,32 +197,14 @@ public:
 		block_decl_stmt->init_expr = list_expr;
 	}
 
-	virtual ~dyn_var_base() = default;
+	virtual ~dyn_var() = default;
 
-	dyn_var_base* addr(void) {
+	dyn_var* addr(void) {
 		return this;
 	}
 
 };
 
-template<typename BT>
-builder_base<BT>::builder_base(const var &a) {
-	assert(builder_context::current_builder_context != nullptr);
-	block_expr = nullptr;
-	if (builder_context::current_builder_context->bool_vector.size() > 0)
-		return;
-	
-	tracer::tag offset = get_offset_in_function();
-	assert(a.block_var != nullptr);
-	block::var_expr::Ptr var_expr = std::make_shared<block::var_expr>();
-	var_expr->static_offset = offset;
-
-	var_expr->var1 = a.block_var;
-	builder_context::current_builder_context->add_node_to_sequence(
-	    var_expr);
-
-	block_expr = var_expr;
-}
 
 
 template <typename T>

--- a/include/builder/forward_declarations.h
+++ b/include/builder/forward_declarations.h
@@ -9,12 +9,10 @@ namespace builder {
 class builder_root;
 
 // The builder base class
-template <typename BT>
-class builder_base;
+class builder;
 
 struct sentinel_member;
 
-using builder = builder_base<sentinel_member>;
 
 template<typename T>
 using is_builder_type = typename std::is_base_of<builder_root, T>;
@@ -29,21 +27,15 @@ class static_var;
 // The var classes declaration
 class var;
 
-template <typename T, typename MT, typename BT>
-class dyn_var_base;
-
 template <typename T>
-using dyn_var = dyn_var_base<T, sentinel_member, builder>;
+class dyn_var;
 
 template <typename T>
 using is_dyn_var_type = std::is_base_of<var, T>;
 
 
 
-struct member_base;
 
-template <typename T>
-using is_member_type = std::is_base_of<member_base, T>;
 
 
 template <typename T>

--- a/include/builder/operator_overload.h
+++ b/include/builder/operator_overload.h
@@ -7,7 +7,7 @@ namespace builder {
 
 template <typename T>
 struct is_possible_builder {
-	constexpr static bool value = is_builder_type<T>::value || is_dyn_var_type<T>::value || is_member_type<T>::value;
+	constexpr static bool value = is_builder_type<T>::value || is_dyn_var_type<T>::value;
 };
 
 
@@ -22,10 +22,6 @@ struct return_type_helper <T, typename std::enable_if<is_builder_type<T>::value>
 template <typename T>
 struct return_type_helper <T, typename std::enable_if<!is_builder_type<T>::value && is_dyn_var_type<T>::value>::type> {
 	typedef typename T::associated_BT type;
-};
-template <typename T>
-struct return_type_helper <T, typename std::enable_if<!is_builder_type<T>::value && !is_dyn_var_type<T>::value && is_member_type<T>::value>::type> {
-	typedef typename T::member_associated_BT type;
 };
 
 template <typename T1, typename T2, class Enable = void>
@@ -143,24 +139,6 @@ typename return_type_helper<T>::type operator&(const T &a) {
 	return ret_type(a).template builder_unary_op<block::addr_of_expr>();
 }
 
-template <typename MT>
-void create_return_stmt(const builder_base<MT> &a) {
-	assert(builder_context::current_builder_context != nullptr);
-	builder_context::current_builder_context->remove_node_from_sequence(
-	    a.block_expr);
-	assert(builder_context::current_builder_context->current_block_stmt !=
-	       nullptr);
-	builder_context::current_builder_context->commit_uncommitted();
-
-	if (builder_context::current_builder_context->bool_vector.size() > 0)
-		return;
-	block::return_stmt::Ptr ret_stmt =
-	    std::make_shared<block::return_stmt>();
-	ret_stmt->static_offset = a.block_expr->static_offset;
-	ret_stmt->return_val = a.block_expr;
-	builder_context::current_builder_context->add_stmt_to_current_block(
-	    ret_stmt);
-}
 
 
 }

--- a/samples/outputs/sample31
+++ b/samples/outputs/sample31
@@ -11,14 +11,14 @@ FUNC_DECL
       SCALAR_TYPE (INT)
       VAR (var1)
       PLUS_EXPR
-        MEMBER_ACCESS_EXPR (var1)
-          PLUS_EXPR
-            INT_CONST (3)
+        PLUS_EXPR
+          INT_CONST (3)
+          MEMBER_ACCESS_EXPR (var1)
             VAR_EXPR
               VAR (var0)
-        MEMBER_ACCESS_EXPR (var1)
-          MUL_EXPR
-            INT_CONST (5)
+        MUL_EXPR
+          INT_CONST (5)
+          MEMBER_ACCESS_EXPR (var1)
             VAR_EXPR
               VAR (var0)
     DECL_STMT
@@ -34,7 +34,7 @@ FUNC_DECL
         VAR (var2)
 int func1 (int arg0) {
   int var0 = arg0;
-  int var1 = (3 + var0).var1 + (5 * var0).var1;
+  int var1 = (3 + var0.var1) + (5 * var0.var1);
   int var2 = var1.neighbor + 2;
   return var2;
 }

--- a/samples/outputs/sample33
+++ b/samples/outputs/sample33
@@ -1,0 +1,37 @@
+STMT_BLOCK
+  DECL_STMT
+    NAMED_TYPE (FooT)
+    VAR (var0)
+    NO_INITIALIZATION
+  EXPR_STMT
+    ASSIGN_EXPR
+      VAR_EXPR
+        VAR (var0)
+      PLUS_EXPR
+        VAR_EXPR
+          VAR (var0)
+        INT_CONST (1)
+  DECL_STMT
+    SCALAR_TYPE (INT)
+    VAR (var1)
+    MEMBER_ACCESS_EXPR (member)
+      VAR_EXPR
+        VAR (var0)
+  DECL_STMT
+    NAMED_TYPE (FooT)
+    VAR (var2)
+    VAR_EXPR
+      VAR (var0)
+  EXPR_STMT
+    ASSIGN_EXPR
+      VAR_EXPR
+        VAR (var2)
+      VAR_EXPR
+        VAR (var0)
+{
+  FooT var0;
+  var0 = var0 + 1;
+  int var1 = var0.member;
+  FooT var2 = var0;
+  var2 = var0;
+}

--- a/samples/sample33.cpp
+++ b/samples/sample33.cpp
@@ -1,0 +1,44 @@
+#include "blocks/c_code_generator.h"
+#include "builder/builder.h"
+#include "builder/builder_context.h"
+#include "builder/static_var.h"
+#include "builder/dyn_var.h"
+#include <iostream>
+using builder::dyn_var;
+using builder::static_var;
+using builder::as_member_of;
+
+const char foo_t_name[] = "FooT";
+using foo_t = typename builder::name<foo_t_name>;
+
+class FooT: public dyn_var<foo_t> {
+public:
+	using dyn_var<foo_t>::dyn_var;
+	using dyn_var<foo_t>::operator=;
+	FooT(const FooT &t): dyn_var<foo_t>((builder::builder)t) {}
+	builder::builder operator= (const FooT &t) {
+		return (*this) = (builder::builder)t;
+	}	
+
+	dyn_var<int> member = as_member_of(this, "member");
+};
+
+
+
+static void bar(void) {
+	FooT g;
+	g = g + 1;
+	dyn_var<int> x = g.member;
+	FooT h = g;
+	h = g;
+}
+
+
+
+int main(int argc, char *argv[]) {
+	builder::builder_context context;
+	auto ast = context.extract_ast_from_function(bar);
+	ast->dump(std::cout, 0);
+	block::c_code_generator::generate_code(ast, std::cout, 0);
+	return 0;
+}

--- a/src/builder/builder.cpp
+++ b/src/builder/builder.cpp
@@ -5,24 +5,66 @@
 
 namespace builder {
 
-
-
-
-
 template <>
 std::vector<block::type::Ptr> extract_type_vector_dyn<>(void) {
 	std::vector<block::type::Ptr> empty_vector;
 	return empty_vector;
 }
 
-block::expr::Ptr member_base::get_parent() const {
-	return nullptr;
-}
 dyn_var_consume::dyn_var_consume(const var& a) {
 	block_var = a.block_var;
 }
 dyn_var_consume::dyn_var_consume(const dyn_var_consume& a) {
 	block_var = a.block_var;
+}
+
+builder builder::sentinel_builder;
+void create_return_stmt(const builder &a) {
+	assert(builder_context::current_builder_context != nullptr);
+	builder_context::current_builder_context->remove_node_from_sequence(
+	    a.block_expr);
+	assert(builder_context::current_builder_context->current_block_stmt !=
+	       nullptr);
+	builder_context::current_builder_context->commit_uncommitted();
+
+	if (builder_context::current_builder_context->bool_vector.size() > 0)
+		return;
+	block::return_stmt::Ptr ret_stmt =
+	    std::make_shared<block::return_stmt>();
+	ret_stmt->static_offset = a.block_expr->static_offset;
+	ret_stmt->return_val = a.block_expr;
+	builder_context::current_builder_context->add_stmt_to_current_block(
+	    ret_stmt);
+}
+builder::builder(const var &a) {
+	assert(builder_context::current_builder_context != nullptr);
+	block_expr = nullptr;
+	if (builder_context::current_builder_context->bool_vector.size() > 0)
+		return;
+	
+	tracer::tag offset = get_offset_in_function();
+
+	if (a.is_member) {
+		assert(a.parent_var != nullptr);
+		builder parent_expr_builder = (builder)(*a.parent_var);		
+		
+		block::member_access_expr::Ptr member = std::make_shared<block::member_access_expr>();
+		member->parent_expr = parent_expr_builder.block_expr;
+		builder_context::current_builder_context->remove_node_from_sequence(member->parent_expr);
+		member->member_name = a.var_name;
+
+		block_expr = member;
+	} else {
+		assert(a.block_var != nullptr);
+		block::var_expr::Ptr var_expr = std::make_shared<block::var_expr>();
+		var_expr->static_offset = offset;
+
+		var_expr->var1 = a.block_var;
+		builder_context::current_builder_context->add_node_to_sequence(
+		    var_expr);
+
+		block_expr = var_expr;
+	}
 }
 
 } // namespace builder


### PR DESCRIPTION
…for members


This change removes the CRTP + Mixin implementation of builder::builder and builder::dyn_var. This simplifies the implementation and allows the extension by inheriting from dyn_var. This is restrictive because it doesn't allow members for arbitrary expressions. We don't need that for most applications and a simple cast can be introduced to allow it. 

This change also adds the builder::as_member_of helper to initialize a dyn_var as a member of other var. This eliminates the declaration for the member and creates expressions that reference the parent expression. 
