### PR TITLE
Added support for allowing compound exprs to be stored inside dyn_var…

### DIFF
--- a/include/builder/forward_declarations.h
+++ b/include/builder/forward_declarations.h
@@ -55,6 +55,7 @@ struct extract_signature_from_lambda;
 struct dyn_var_sentinel_type {
 
 };
+
 // This class is used for creating exact replicas of a variable
 // One possible use if when initializing args for func_decls
 class dyn_var_consume {

--- a/samples/outputs/sample33
+++ b/samples/outputs/sample33
@@ -28,10 +28,27 @@ STMT_BLOCK
         VAR (var2)
       VAR_EXPR
         VAR (var0)
+  DECL_STMT
+    POINTER_TYPE
+      NAMED_TYPE (FooT)
+    VAR (var3)
+    ADDR_OF_EXPR
+      VAR_EXPR
+        VAR (var0)
+  EXPR_STMT
+    ASSIGN_EXPR
+      MEMBER_ACCESS_EXPR (member)
+        SQ_BKT_EXPR
+          VAR_EXPR
+            VAR (var0)
+          INT_CONST (0)
+      INT_CONST (0)
 {
   FooT var0;
   var0 = var0 + 1;
   int var1 = var0.member;
   FooT var2 = var0;
   var2 = var0;
+  FooT* var3 = (&(var0));
+  (var0[0]).member = 0;
 }

--- a/samples/sample33.cpp
+++ b/samples/sample33.cpp
@@ -31,6 +31,8 @@ static void bar(void) {
 	dyn_var<int> x = g.member;
 	FooT h = g;
 	h = g;
+	dyn_var<foo_t*> ptr = &g;
+	((FooT)(builder::cast)g[0]).member = 0;		
 }
 
 

--- a/src/builder/builder.cpp
+++ b/src/builder/builder.cpp
@@ -44,7 +44,7 @@ builder::builder(const var &a) {
 	
 	tracer::tag offset = get_offset_in_function();
 
-	if (a.is_member) {
+	if (a.current_state == var::member_var) {
 		assert(a.parent_var != nullptr);
 		builder parent_expr_builder = (builder)(*a.parent_var);		
 		
@@ -52,9 +52,15 @@ builder::builder(const var &a) {
 		member->parent_expr = parent_expr_builder.block_expr;
 		builder_context::current_builder_context->remove_node_from_sequence(member->parent_expr);
 		member->member_name = a.var_name;
-
+		builder_context::current_builder_context->add_node_to_sequence(member);
+		
 		block_expr = member;
-	} else {
+	} else if (a.current_state == var::compound_expr) {
+		assert(a.encompassing_expr != nullptr);
+		block_expr = a.encompassing_expr;
+		// For now don't remove this expr from the uncommitted list
+		// It should be removed when it is used
+	} else if (a.current_state == var::standalone_var) {
 		assert(a.block_var != nullptr);
 		block::var_expr::Ptr var_expr = std::make_shared<block::var_expr>();
 		var_expr->static_offset = offset;


### PR DESCRIPTION
…. This specifically allows casting compound expr lvalues to be casted as types inheriting from dyn_var for member access