### PR TITLE
Fixed the pesky while(1) break bug

### DIFF
--- a/include/blocks/loop_finder.h
+++ b/include/blocks/loop_finder.h
@@ -20,5 +20,11 @@ public:
 	virtual void visit(goto_stmt::Ptr);
 };
 
+class continue_finder: public block_visitor {
+public: 
+	using block_visitor::visit;
+	bool has_continue = false;
+	virtual void visit(continue_stmt::Ptr);
+};
 } // namespace block
 #endif

--- a/samples/outputs/sample34
+++ b/samples/outputs/sample34
@@ -1,0 +1,12 @@
+void bar (void) {
+  int var0 = 5;
+  for (int var1 = 0; var1 < 100; var1 = var1 + 1) {
+    if (var1 == var0) {
+    } else {
+      continue;
+    }
+    var0 = var1;
+    break;
+  }
+}
+

--- a/samples/sample34.cpp
+++ b/samples/sample34.cpp
@@ -1,0 +1,26 @@
+// Include the headers
+#include "blocks/c_code_generator.h"
+#include "builder/static_var.h"
+#include "builder/dyn_var.h"
+#include <iostream>
+
+// Include the BuildIt types
+using builder::dyn_var;
+using builder::static_var;
+static void bar(void) {
+     // Insert code to stage here
+     dyn_var<int> x = 5;
+     for (dyn_var<int> i = 0; i < 100; i = i + 1) {
+         if (i == x) {
+             x = i;
+             break;
+         }
+     }
+}
+
+int main(int argc, char* argv[]) {
+    block::c_code_generator::generate_code(builder::builder_context().extract_function_ast(bar, "bar"), std::cout, 0);
+    return 0;
+}
+
+

--- a/src/builder/builder_context.cpp
+++ b/src/builder/builder_context.cpp
@@ -265,6 +265,7 @@ trim_common_from_back(block::stmt::Ptr ast1, block::stmt::Ptr ast2) {
 			}
 		}
 	}
+
 	std::reverse(trimmed_stmts.begin(), trimmed_stmts.end());
 	return {trimmed_stmts, split_decls};
 }


### PR DESCRIPTION
This PR fixes an old bug in BuildIt where sometimes BuildIt would produce code like this - 

```
while (1) {
    break;
}
```
if (...) { 
   ... 
   continue;
}
```

This was actually wrong because we were actually peeling out statements (or trimming_from_parents) that still have a continue in them. 

We have now changed to check if the last statement that we are trying to peel (before a break) has a continue. If yes, we don't peel it. This makes BuildIt generate correct code.

Secondly, while detecting for loops, BuildIt always expects the main loop back paths (not from continue) to have an update. This is not necessary, updates could be found from continues too. Or if nothing, one can just create an empty update. We have also changed this similarly. 
