### PR TITLE
Don;t merge decl before for loops if the variable is used after

### DIFF
--- a/include/blocks/for_loop_finder.h
+++ b/include/blocks/for_loop_finder.h
@@ -10,5 +10,15 @@ public:
 	stmt::Ptr ast;
 	virtual void visit(stmt_block::Ptr) override;
 };
+
+
+class var_use_finder: public block_visitor {
+public:
+	using block_visitor::visit;
+	var::Ptr to_find;
+	bool found = false;
+	virtual void visit(var_expr::Ptr) override;
+
+};
 } // namespace block
 #endif

--- a/samples/outputs/sample35
+++ b/samples/outputs/sample35
@@ -1,0 +1,48 @@
+FUNC_DECL
+  SCALAR_TYPE (VOID)
+  STMT_BLOCK
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (var0)
+      INT_CONST (0)
+    FOR_STMT
+      EXPR_STMT
+        INT_CONST (0)
+      LT_EXPR
+        VAR_EXPR
+          VAR (var0)
+        INT_CONST (100)
+      ASSIGN_EXPR
+        VAR_EXPR
+          VAR (var0)
+        PLUS_EXPR
+          VAR_EXPR
+            VAR (var0)
+          INT_CONST (1)
+      STMT_BLOCK
+    FOR_STMT
+      EXPR_STMT
+        ASSIGN_EXPR
+          VAR_EXPR
+            VAR (var0)
+          INT_CONST (0)
+      LT_EXPR
+        VAR_EXPR
+          VAR (var0)
+        INT_CONST (100)
+      ASSIGN_EXPR
+        VAR_EXPR
+          VAR (var0)
+        PLUS_EXPR
+          VAR_EXPR
+            VAR (var0)
+          INT_CONST (1)
+      STMT_BLOCK
+void bar (void) {
+  int var0 = 0;
+  for (0; var0 < 100; var0 = var0 + 1) {
+  }
+  for (var0 = 0; var0 < 100; var0 = var0 + 1) {
+  }
+}
+

--- a/samples/sample35.cpp
+++ b/samples/sample35.cpp
@@ -1,0 +1,25 @@
+// Include the headers
+#include "blocks/c_code_generator.h"
+#include "builder/static_var.h"
+#include "builder/dyn_var.h"
+#include <iostream>
+
+// Include the BuildIt types
+using builder::dyn_var;
+using builder::static_var;
+static void bar(void) {
+    dyn_var<int> i = 0;
+    for (; i < 100; i = i + 1) {
+    }
+    for (i = 0; i < 100; i = i + 1) {
+    }
+}
+
+int main(int argc, char* argv[]) {
+	builder::builder_context context;
+	auto ast = context.extract_function_ast(bar, "bar");
+	ast->dump(std::cout, 0);
+	block::c_code_generator::generate_code(ast, std::cout, 0);
+}
+
+


### PR DESCRIPTION
BuildIt had a bug while converting while loops into for loops. For code like this - 

```
dyn_var<int> i = 0; 

for (; i < 100; i = i + 1) {...}
for (i = 0; i < 100; i = i + 1) {...}
```

BuildIt would merge the declaration of `i` into the first for loop. This isn't correct because the variable is used after. 

This change fixes the bug by changing the for_loop_finder pass to check if the variable has more uses after the loop before merging the decl. 
