### PR TITLE
Added support for Template parameters for builder::name

### DIFF
--- a/include/blocks/var.h
+++ b/include/blocks/var.h
@@ -62,6 +62,7 @@ class named_type : public type {
 public:
 	typedef std::shared_ptr<named_type> Ptr;
 	std::string type_name;
+	std::vector<type::Ptr> template_args;
 	virtual void accept(block_visitor *a) override { a->visit(self<named_type>()); }
 
 	virtual void dump(std::ostream &, int) override;

--- a/include/builder/block_type_extractor.h
+++ b/include/builder/block_type_extractor.h
@@ -230,17 +230,38 @@ public:
 	}
 };
 
-template <const char* N>
+template <const char* N, typename...Args>
 struct name {
 	
 };
 
-template <const char* N>
-class type_extractor<name<N>> {
+template <typename...Args>
+struct extract_type_from_args;
+
+template <typename T1, typename...Args>
+struct extract_type_from_args<T1, Args...> {
+	static std::vector<block::type::Ptr> get_types() {
+		auto a = extract_type_from_args<Args...>::get_types();
+		a.insert(a.begin(), type_extractor<T1>::extract_type());
+		return a;
+	}
+};
+
+template <>
+struct extract_type_from_args<> {
+	static std::vector<block::type::Ptr> get_types() {
+		return std::vector<block::type::Ptr>();
+	}
+};
+
+
+template <const char* N, typename...Args>
+class type_extractor<name<N, Args...>> {
 public:
 	static block::type::Ptr extract_type(void) {
 		block::named_type::Ptr type = std::make_shared<block::named_type>();
 		type->type_name = N;
+		type->template_args = extract_type_from_args<Args...>::get_types();
 		return type;	
 	}
 };

--- a/samples/outputs/sample32
+++ b/samples/outputs/sample32
@@ -11,7 +11,22 @@ STMT_BLOCK
         VAR_EXPR
           VAR (var0)
         INT_CONST (1)
+  DECL_STMT
+    NAMED_TYPE (FooT)
+      SCALAR_TYPE (INT)
+    VAR (var1)
+    NO_INITIALIZATION
+  EXPR_STMT
+    ASSIGN_EXPR
+      VAR_EXPR
+        VAR (var1)
+      PLUS_EXPR
+        VAR_EXPR
+          VAR (var1)
+        INT_CONST (1)
 {
   GraphT var0;
   var0 = var0 + 1;
+  FooT<int> var1;
+  var1 = var1 + 1;
 }

--- a/samples/sample32.cpp
+++ b/samples/sample32.cpp
@@ -10,9 +10,16 @@ using builder::static_var;
 constexpr char graph_t_name[] = "GraphT";
 using graph_t = typename builder::name<graph_t_name>;
 
+constexpr char foo_t_name[] = "FooT";
+template <typename T>
+using foo_t = typename builder::name<foo_t_name, T>;
+
 static void bar(void) {
 	dyn_var<graph_t> g;
 	g = g + 1;
+
+	dyn_var<foo_t<int>> f;
+	f = f + 1;
 }
 
 int main(int argc, char *argv[]) {

--- a/src/blocks/block_replacer.cpp
+++ b/src/blocks/block_replacer.cpp
@@ -172,7 +172,14 @@ void block_replacer::visit(builder_var_type::Ptr a) {
 	a->closure_type = rewrite<type>(a->closure_type);
 	node = a;
 }
-void block_replacer::visit(named_type::Ptr a) {node=a;}
+void block_replacer::visit(named_type::Ptr a) {
+	std::vector<type::Ptr> new_args;
+	for (auto a: a->template_args) {
+		new_args.push_back(rewrite<type>(a));
+	}
+	a->template_args = new_args;
+	node=a;
+}
 void block_replacer::visit(func_decl::Ptr a) {
 	a->return_type = rewrite<type>(a->return_type);
 	for (unsigned int i = 0; i < a->args.size(); i++) {

--- a/src/blocks/block_visitor.cpp
+++ b/src/blocks/block_visitor.cpp
@@ -142,7 +142,11 @@ void block_visitor::visit(array_type::Ptr a) { a->element_type->accept(this); }
 void block_visitor::visit(builder_var_type::Ptr a) {
 	a->closure_type->accept(this);
 }
-void block_visitor::visit(named_type::Ptr a) {}
+void block_visitor::visit(named_type::Ptr a) {
+	for (auto a: a->template_args) {
+		a->accept(this);
+	}
+}
 void block_visitor::visit(func_decl::Ptr a) {
 	a->return_type->accept(this);
 	for (auto arg : a->args)

--- a/src/blocks/c_code_generator.cpp
+++ b/src/blocks/c_code_generator.cpp
@@ -113,6 +113,17 @@ void c_code_generator::visit(scalar_type::Ptr type) {
 }
 void c_code_generator::visit(named_type::Ptr type) {
 	oss << type->type_name;
+	if (type->template_args.size()) {
+		oss << "<";
+		bool needs_comma = false;
+		for (auto a: type->template_args) {
+			if (needs_comma)
+				oss << ", ";
+			needs_comma = true;
+			a->accept(this);	
+		}
+		oss << ">";
+	}
 }
 void c_code_generator::visit(pointer_type::Ptr type) {
 	if (!isa<scalar_type>(type->pointee_type) &&

--- a/src/blocks/var.cpp
+++ b/src/blocks/var.cpp
@@ -76,5 +76,7 @@ void named_type::dump(std::ostream &oss, int indent) {
 	printer::indent(oss, indent);
 	oss << "NAMED_TYPE (";
 	oss << type_name << ")" << std::endl;
+	for (unsigned int i = 0; i < template_args.size(); i++) 
+		template_args[i]->dump(oss, indent + 1);
 }
 } // namespace block


### PR DESCRIPTION
This change allows adding template parameters to named type. `builder::name` now accepts extract template arguments that can be forwarded to the generated type as is by applying type_extractor and printer for each of them. 

This feature makes it easy to implement custom types that inherit from dyn_var<name<T>> to be templated. One of the use cases is in convolutions to implement ImageT. 
