### PR TITLE
Allow template specialization as a method for extending dyn_var

### DIFF
--- a/include/builder/builder_context.h
+++ b/include/builder/builder_context.h
@@ -129,7 +129,7 @@ private:
 	friend var;
 
 	template <typename T>
-	friend class dyn_var;
+	friend class dyn_var_impl;
 
 	template <typename T>
 	friend class static_var;

--- a/include/builder/dyn_var.h
+++ b/include/builder/dyn_var.h
@@ -58,14 +58,14 @@ struct as_compound_expr {
 using cast = as_compound_expr;
 
 template<typename T>
-class dyn_var: public var{
+class dyn_var_impl: public var{
 public:
 	
 	typedef builder BT;
-	typedef dyn_var<T> my_type;
+	typedef dyn_var_impl<T> my_type;
+	// These are required for overloads
 	typedef BT associated_BT;
 	typedef T stored_type;
-	typedef my_type super;
 		
 	template <typename... types>
 	BT operator()(const types &... args) {
@@ -85,12 +85,12 @@ public:
 		return (BT)*this = a;
 	}
 
-	BT operator=(const dyn_var<T> &a) {
+	BT operator=(const dyn_var_impl<T> &a) {
 		return (BT) * this = a;
 	}
 
 	template <typename TO>
-	BT operator=(const dyn_var<TO> &a) {
+	BT operator=(const dyn_var_impl<TO> &a) {
 		return (BT) * this = a;
 	}
 
@@ -140,7 +140,7 @@ public:
 		builder_context::current_builder_context->add_stmt_to_current_block(decl_stmt);
 	}
 	// Basic and other constructors
-	dyn_var(const char* name=nullptr) { 
+	dyn_var_impl(const char* name=nullptr) { 
 		if (builder_context::current_builder_context == nullptr) {
 			create_dyn_var(true); 
 			if (name != nullptr) {
@@ -150,7 +150,7 @@ public:
 		} else
 			create_dyn_var(false); 
 	}
-	dyn_var(const dyn_var_sentinel_type& a, std::string name = "") {
+	dyn_var_impl(const dyn_var_sentinel_type& a, std::string name = "") {
 		create_dyn_var(true);
 		if (name != "") {
 			block_var->var_name = name;
@@ -159,16 +159,23 @@ public:
 	}
         // Constructor to initialize a dyn_var as member
         // This declaration does not produce a declaration
-        dyn_var(const as_member_of &a) {
+        dyn_var_impl(const as_member_of &a) {
 		current_state = member_var;
 		parent_var = a.parent_var;
 		var_name = a.member_name;            
 		block_var = nullptr;
 		block_decl_stmt = nullptr;
 	}
-	// Constructor to initialize a dyn_var as a compound expr
-	// This declaration also does not produce a declaration
-	dyn_var(const as_compound_expr &a) {
+	// Constructor and operator = to initialize a dyn_var as a compound expr
+	// This declaration also does not produce a declaration or assign stmt
+	dyn_var_impl(const as_compound_expr &a) {
+		current_state = compound_expr;
+		parent_var = nullptr;
+		block_var = nullptr;
+		block_decl_stmt = nullptr;	
+		encompassing_expr = a.encompassing_expr;	
+	}
+	void operator = (const as_compound_expr& a) {
 		current_state = compound_expr;
 		parent_var = nullptr;
 		block_var = nullptr;
@@ -177,23 +184,23 @@ public:
 	}
 	// A very special move constructor that is used to create exact 
 	// replicas of variables
-	dyn_var(const dyn_var_consume &a) {
+	dyn_var_impl(const dyn_var_consume &a) {
 		block_var = a.block_var;
 		var_name = block_var->var_name;
 		block_decl_stmt = nullptr;	
 		
 	}
 
-	dyn_var(const my_type &a) : my_type((BT)a) {}
+	dyn_var_impl(const my_type &a) : my_type((BT)a) {}
 
 	
 	template <typename TO>
-	dyn_var(const dyn_var<TO> &a) : my_type((BT)a) {}
+	dyn_var_impl(const dyn_var_impl<TO> &a) : my_type((BT)a) {}
 	
 	template <typename TO>
-	dyn_var(const static_var<TO> &a) : my_type((TO)a) {}
+	dyn_var_impl(const static_var<TO> &a) : my_type((TO)a) {}
 
-	dyn_var(const BT &a) {
+	dyn_var_impl(const BT &a) {
 		builder_context::current_builder_context->remove_node_from_sequence(a.block_expr);
 		create_dyn_var();
 		if (builder_context::current_builder_context->bool_vector.size() > 0)
@@ -201,12 +208,12 @@ public:
 		block_decl_stmt->init_expr = a.block_expr;
 	}
 
-	dyn_var(const int &a) : my_type((BT)a) {}
-	dyn_var(const bool &a) : my_type((BT)a) {}
-	dyn_var(const double &a) : my_type((BT)a) {}
-	dyn_var(const float &a) : my_type((BT)a) {}
+	dyn_var_impl(const int &a) : my_type((BT)a) {}
+	dyn_var_impl(const bool &a) : my_type((BT)a) {}
+	dyn_var_impl(const double &a) : my_type((BT)a) {}
+	dyn_var_impl(const float &a) : my_type((BT)a) {}
 
-	dyn_var(const std::initializer_list<BT> &_a) {
+	dyn_var_impl(const std::initializer_list<BT> &_a) {
 		std::vector<BT> a(_a);
 
 		assert(builder_context::current_builder_context != nullptr);
@@ -226,14 +233,40 @@ public:
 		block_decl_stmt->init_expr = list_expr;
 	}
 
-	virtual ~dyn_var() = default;
+	// This is defined specifically so the derived classes 
+	// don't have to define them again
+	dyn_var_impl(const dyn_var<T> &t): dyn_var_impl<T>((builder)t){}
 
-	dyn_var* addr(void) {
-		return this;
+	virtual ~dyn_var_impl() = default;
+
+
+	// Assume that _impl objects will never be created
+	// Thus addr can always cast the address to dyn_var<T>
+	dyn_var<T>* addr(void) {
+		// TODO: Consider using dynamic_cast here
+		return (dyn_var<T>*)this;
 	}
 
 };
 
+// Actual dyn_var implementation
+// Split design to allow for easily extending types with specialization
+
+template<typename T>
+class dyn_var: public dyn_var_impl<T> {
+public:
+	typedef dyn_var_impl<T> super;
+	
+	using super::super;
+	using super::operator=;
+
+	// Unfortunately because we are changing the return type, 
+	// the implicitly defined copy assignment will always 
+	// shadow the version the parent defines
+	builder operator= (const dyn_var<T> &t) {
+		return *this = (builder)t;
+	}
+};
 
 
 template <typename T>

--- a/include/builder/dyn_var.h
+++ b/include/builder/dyn_var.h
@@ -233,9 +233,6 @@ public:
 		block_decl_stmt->init_expr = list_expr;
 	}
 
-	// This is defined specifically so the derived classes 
-	// don't have to define them again
-	dyn_var_impl(const dyn_var<T> &t): dyn_var_impl<T>((builder)t){}
 
 	virtual ~dyn_var_impl() = default;
 
@@ -259,6 +256,11 @@ public:
 	
 	using super::super;
 	using super::operator=;
+
+	
+	// Some implementations don't like implicitly declared
+	// constructors so define them here
+	dyn_var(const dyn_var<T> &t): dyn_var_impl<T>((builder)t){}
 
 	// Unfortunately because we are changing the return type, 
 	// the implicitly defined copy assignment will always 

--- a/include/builder/forward_declarations.h
+++ b/include/builder/forward_declarations.h
@@ -28,6 +28,9 @@ class static_var;
 class var;
 
 template <typename T>
+class dyn_var_impl;
+
+template <typename T>
 class dyn_var;
 
 template <typename T>

--- a/samples/outputs/sample38
+++ b/samples/outputs/sample38
@@ -1,0 +1,63 @@
+STMT_BLOCK
+  DECL_STMT
+    NAMED_TYPE (FooT)
+    VAR (var0)
+    NO_INITIALIZATION
+  EXPR_STMT
+    ASSIGN_EXPR
+      VAR_EXPR
+        VAR (var0)
+      PLUS_EXPR
+        VAR_EXPR
+          VAR (var0)
+        INT_CONST (1)
+  DECL_STMT
+    SCALAR_TYPE (INT)
+    VAR (var1)
+    MEMBER_ACCESS_EXPR (member)
+      VAR_EXPR
+        VAR (var0)
+  DECL_STMT
+    NAMED_TYPE (FooT)
+    VAR (var2)
+    VAR_EXPR
+      VAR (var0)
+  EXPR_STMT
+    ASSIGN_EXPR
+      VAR_EXPR
+        VAR (var2)
+      VAR_EXPR
+        VAR (var0)
+  DECL_STMT
+    POINTER_TYPE
+      NAMED_TYPE (FooT)
+    VAR (var3)
+    ADDR_OF_EXPR
+      VAR_EXPR
+        VAR (var0)
+  EXPR_STMT
+    ASSIGN_EXPR
+      MEMBER_ACCESS_EXPR (member)
+        SQ_BKT_EXPR
+          VAR_EXPR
+            VAR (var3)
+          INT_CONST (0)
+      INT_CONST (0)
+  EXPR_STMT
+    ASSIGN_EXPR
+      MEMBER_ACCESS_EXPR (member)
+        SQ_BKT_EXPR
+          VAR_EXPR
+            VAR (var3)
+          INT_CONST (0)
+      INT_CONST (1)
+{
+  FooT var0;
+  var0 = var0 + 1;
+  int var1 = var0.member;
+  FooT var2 = var0;
+  var2 = var0;
+  FooT* var3 = (&(var0));
+  var3->member = 0;
+  var3->member = 1;
+}

--- a/samples/sample38.cpp
+++ b/samples/sample38.cpp
@@ -1,0 +1,79 @@
+#include "blocks/c_code_generator.h"
+#include "builder/builder.h"
+#include "builder/builder_context.h"
+#include "builder/static_var.h"
+#include "builder/dyn_var.h"
+#include <iostream>
+#include <memory>
+using builder::dyn_var;
+using builder::static_var;
+using builder::as_member_of;
+
+const char foo_t_name[] = "FooT";
+using foo_t = typename builder::name<foo_t_name>;
+
+// Use specialization instead of inheritance
+template <>
+class builder::dyn_var<foo_t>: public dyn_var_impl<foo_t> {
+public:
+	typedef dyn_var_impl<foo_t> super;
+	using super::super;
+	using super::operator=;
+	builder operator= (const dyn_var<foo_t> &t) {
+		return (*this) = (builder)t;
+	}	
+	dyn_var(const dyn_var& t): dyn_var_impl((builder)t){}
+
+	dyn_var<int> member = as_member_of(this, "member");
+};
+
+// Create specialization for foo_t* so that we can overload the * operator
+
+template <>
+class builder::dyn_var<foo_t*>: public dyn_var_impl<foo_t*> {
+public:
+	typedef dyn_var_impl<foo_t*> super;
+	using super::super;
+	using super::operator=;
+	builder operator= (const dyn_var<foo_t*> &t) {
+		return (*this) = (builder)t;
+	}	
+	dyn_var(const dyn_var& t): dyn_var_impl((builder)t){}
+	
+	
+	dyn_var<foo_t> operator *() {
+		// Rely on copy elision
+		return (cast)this->operator[](0);
+	}
+
+	// This is POC of how -> operator can
+	// be implemented. Requires the hack of creating a dummy 
+	// member because -> needs to return a pointer. 
+	dyn_var<foo_t> _p = as_member_of(this, "_p");
+	dyn_var<foo_t>* operator->() {
+		_p = (cast)this->operator[](0);
+		return _p.addr();
+	}
+};
+
+
+static void bar(void) {
+	dyn_var<foo_t> g;
+	g = g + 1;
+	dyn_var<int> x = g.member;
+	dyn_var<foo_t> h = g;
+	h = g;
+	dyn_var<foo_t*> ptr = &g;
+	(*ptr).member = 0;	
+	ptr->member = 1;
+}
+
+
+
+int main(int argc, char *argv[]) {
+	builder::builder_context context;
+	auto ast = context.extract_ast_from_function(bar);
+	ast->dump(std::cout, 0);
+	block::c_code_generator::generate_code(ast, std::cout, 0);
+	return 0;
+}


### PR DESCRIPTION
Currently, the only way to extend dyn_var in BuildIt to add member variables is by inheriting from dyn_var<T>. This method works for most cases, but makes it hard to refer to the inner type (for pointers and functions). 

To solve this, we now support template specialization of dyn_var<T> specifically for builder::name types and associated types. The implementation has been moved into a separate dyn_var_impl<T> type so that specializations can simply inherit from it and add members. 

This approach also allows specialization of dyn_var for pointer types allowing overloading the *, [] and -> operators to return dyn_var instead of builder and thus allowing expressions like (*a).member. 

Sample 38 has been added to demonstrate this. 