### PR TITLE
Changes to keep older versions of gcc happy

### DIFF
--- a/include/builder/dyn_var.h
+++ b/include/builder/dyn_var.h
@@ -259,7 +259,8 @@ public:
 	
 	using super::super;
 	using super::operator=;
-
+	
+	dyn_var(): dyn_var_impl<T>() {}
 	
 	// Some implementations don't like implicitly declared
 	// constructors so define them here

--- a/samples/sample33.cpp
+++ b/samples/sample33.cpp
@@ -8,14 +8,16 @@ using builder::dyn_var;
 using builder::static_var;
 using builder::as_member_of;
 
-const char foo_t_name[] = "FooT";
+constexpr char foo_t_name[] = "FooT";
 using foo_t = typename builder::name<foo_t_name>;
 
 class FooT: public dyn_var<foo_t> {
 public:
-	using dyn_var<foo_t>::dyn_var;
+	typedef dyn_var<foo_t> super;
+	using super::super;
 	using dyn_var<foo_t>::operator=;
 	FooT(const FooT &t): dyn_var<foo_t>((builder::builder)t) {}
+	FooT(): dyn_var<foo_t>() {}
 	builder::builder operator= (const FooT &t) {
 		return (*this) = (builder::builder)t;
 	}	

--- a/samples/sample38.cpp
+++ b/samples/sample38.cpp
@@ -9,12 +9,14 @@ using builder::dyn_var;
 using builder::static_var;
 using builder::as_member_of;
 
-const char foo_t_name[] = "FooT";
+constexpr char foo_t_name[] = "FooT";
 using foo_t = typename builder::name<foo_t_name>;
+
+namespace builder {
 
 // Use specialization instead of inheritance
 template <>
-class builder::dyn_var<foo_t>: public dyn_var_impl<foo_t> {
+class dyn_var<foo_t>: public dyn_var_impl<foo_t> {
 public:
 	typedef dyn_var_impl<foo_t> super;
 	using super::super;
@@ -23,6 +25,7 @@ public:
 		return (*this) = (builder)t;
 	}	
 	dyn_var(const dyn_var& t): dyn_var_impl((builder)t){}
+	dyn_var(): dyn_var_impl<foo_t>() {}
 
 	dyn_var<int> member = as_member_of(this, "member");
 };
@@ -30,7 +33,7 @@ public:
 // Create specialization for foo_t* so that we can overload the * operator
 
 template <>
-class builder::dyn_var<foo_t*>: public dyn_var_impl<foo_t*> {
+class dyn_var<foo_t*>: public dyn_var_impl<foo_t*> {
 public:
 	typedef dyn_var_impl<foo_t*> super;
 	using super::super;
@@ -39,7 +42,7 @@ public:
 		return (*this) = (builder)t;
 	}	
 	dyn_var(const dyn_var& t): dyn_var_impl((builder)t){}
-	
+	dyn_var(): dyn_var_impl<foo_t*>() {}	
 	
 	dyn_var<foo_t> operator *() {
 		// Rely on copy elision
@@ -56,6 +59,7 @@ public:
 	}
 };
 
+}
 
 static void bar(void) {
 	dyn_var<foo_t> g;

--- a/src/blocks/block_replacer.cpp
+++ b/src/blocks/block_replacer.cpp
@@ -174,8 +174,8 @@ void block_replacer::visit(builder_var_type::Ptr a) {
 }
 void block_replacer::visit(named_type::Ptr a) {
 	std::vector<type::Ptr> new_args;
-	for (auto a: a->template_args) {
-		new_args.push_back(rewrite<type>(a));
+	for (auto b: a->template_args) {
+		new_args.push_back(rewrite<type>(b));
 	}
 	a->template_args = new_args;
 	node=a;

--- a/src/blocks/block_visitor.cpp
+++ b/src/blocks/block_visitor.cpp
@@ -142,8 +142,8 @@ void block_visitor::visit(array_type::Ptr a) { a->element_type->accept(this); }
 void block_visitor::visit(builder_var_type::Ptr a) {
 	a->closure_type->accept(this);
 }
-void block_visitor::visit(named_type::Ptr a) {
-	for (auto a: a->template_args) {
+void block_visitor::visit(named_type::Ptr x) {
+	for (auto a: x->template_args) {
 		a->accept(this);
 	}
 }


### PR DESCRIPTION
Certain older versions of gcc for example gcc 5.4 that we use on the BuildIt online tool complains about some code patterns that we use. I am not entirely sure if this is because the standard isn't properly supported or we are using some non standard features. Either way, this change set correct the ones that show up every time. 