### PR TITLE
Fixed a bug in var_finder

### DIFF
--- a/include/builder/dyn_var.h
+++ b/include/builder/dyn_var.h
@@ -120,7 +120,8 @@ public:
 			block::var::Ptr dyn_var = std::make_shared<block::var>();
 			dyn_var->var_type = create_block_type();
 			block_var = dyn_var;
-			dyn_var->preferred_name = util::find_variable_name(this);
+			// Don't try to obtain preferred names for objects created without context
+			//dyn_var->preferred_name = util::find_variable_name(this);
 			return;
 		}
 		assert(builder_context::current_builder_context != nullptr);

--- a/src/util/tracer.cpp
+++ b/src/util/tracer.cpp
@@ -12,8 +12,8 @@ static void set_call_point(void) {
 #ifdef TRACER_USE_FLIMITS
 	unsigned long long function_end = (unsigned long long)(void *)builder::lambda_wrapper_close;
 #endif
-	void *buffer[20];
-	int backtrace_size = backtrace(buffer, 20);
+	void *buffer[50];
+	int backtrace_size = backtrace(buffer, 50);
 	char **backtrace_functions = backtrace_symbols(buffer, backtrace_size);
 	int i;
 	bool found = false;
@@ -64,10 +64,10 @@ tag get_offset_in_function_impl(
 	if (call_point == 0) {
 		set_call_point();
 	}
-	void *buffer[20];
+	void *buffer[50];
 	tag new_tag;
 	// First add the RIP pointers
-	int backtrace_size = backtrace(buffer, 20);
+	int backtrace_size = backtrace(buffer, 50);
 	for (int i = 0; i < backtrace_size; i++) {
 		if ((unsigned long long)buffer[i] == call_point)
 			break;

--- a/src/util/var_finder.cpp
+++ b/src/util/var_finder.cpp
@@ -14,7 +14,7 @@
 #include <map>
 #include <algorithm>
 #include <iostream>
-
+#include <link.h>
 
 namespace util {
 
@@ -164,12 +164,13 @@ static std::string find_variable_with_cursor(void* addr, unw_cursor_t &cursor) {
 	(void) var_offset;
 
 	Dl_info info;
-	if (!dladdr((void*)ip, &info)) {
+	struct link_map *map;
+	if (!dladdr1((void*)ip, &info, (void**)&map, RTLD_DL_LINKMAP)) {
 		return "";
 	}
 
 	
-	unsigned long long find_offset = (unsigned long long)((unsigned long long)ip - (unsigned long long)info.dli_fbase);
+	unsigned long long find_offset = (unsigned long long)((unsigned long long)ip - (unsigned long long)map->l_addr);
 	(void) find_offset;
 	// Now that we have obtained the base address and the offset for the function
 	// we can load the dwarf


### PR DESCRIPTION
var_finder was previously using Dl_info.dli_fbase to compute function offset which is not the right method. Use link_map.l_addr instead. 