### PR TITLE
Implemented a new context flag for unstructured code generation

### DIFF
--- a/include/blocks/loop_roll.h
+++ b/include/blocks/loop_roll.h
@@ -1,6 +1,7 @@
 #ifndef BLOCK_LOOP_ROLL_H
 #define BLOCK_LOOP_ROLL_H
 #include "blocks/block_visitor.h"
+#include "blocks/block_replacer.h"
 #include "blocks/stmt.h"
 
 namespace block {
@@ -19,12 +20,16 @@ public:
 	virtual void visit(int_const::Ptr);
 };
 
-class constant_replacer : public block_visitor {
+class constant_replacer : public block_replacer {
 public:
 	using block_visitor::visit;
 	std::vector<expr::Ptr> replace;
 	int curr_index = 0;
 
+
+	virtual void visit(int_const::Ptr);
+
+	/*
 	// Handle plus expr for now
 	// Add more expressions later or use expression rewriter instead
 	virtual void visit(plus_expr::Ptr);
@@ -32,6 +37,7 @@ public:
 	virtual void visit(minus_expr::Ptr);
 	virtual void visit(div_expr::Ptr);
 	virtual void visit(sq_bkt_expr::Ptr);
+	*/
 };
 
 } // namespace block

--- a/include/builder/builder_context.h
+++ b/include/builder/builder_context.h
@@ -64,6 +64,9 @@ public:
 
 	bool use_memoization = true;
 	bool run_rce = false;
+	bool feature_unstructured = false;
+
+
 	bool is_visited_tag(tracer::tag &new_tag);
 	void erase_tag(tracer::tag &erase_tag);
 

--- a/include/builder/builder_dynamic.h
+++ b/include/builder/builder_dynamic.h
@@ -14,10 +14,8 @@
 namespace builder {
 
 template <typename FT, typename...ArgsT>
-auto compile_function(FT f, ArgsT...args) -> void* {
-	builder_context context;	
-	// Currently we will use an unconfigured context
-	// Can take in extra parameters or a context object
+auto compile_function_with_context(builder_context context, FT f, ArgsT...args) -> void* {
+
 	auto ast = context.extract_function_ast(f, "execute", args...);
 	// Proactively run RCE
 	block::eliminate_redundant_vars(ast);		
@@ -59,6 +57,13 @@ auto compile_function(FT f, ArgsT...args) -> void* {
 		assert(false && "Loading compiled module failed\n");
 	}
 	return function;
+}
+
+template <typename FT, typename...ArgsT>
+auto compile_function(FT f, ArgsT...args) -> void* {
+	// Use an unconfigured context object
+	builder_context context;
+	return compile_function_with_context(context, f, args...);
 }
 
 }

--- a/include/builder/dyn_var.h
+++ b/include/builder/dyn_var.h
@@ -60,6 +60,7 @@ using cast = as_compound_expr;
 
 struct with_name {
 	std::string name;
+	with_name(const std::string &n): name(n) {}
 };
 
 template<typename T>

--- a/samples/outputs.var_names/sample40
+++ b/samples/outputs.var_names/sample40
@@ -1,0 +1,69 @@
+#include <string.h>
+int match_re (char* arg1) {
+  int var3;
+  int var4;
+  int var5;
+  int str_len_1 = strlen(arg1);
+  int to_match_2 = 0;
+  if (to_match_2 < str_len_1) {
+    if (arg1[to_match_2] == 97) {
+      to_match_2 = to_match_2 + 1;
+      label0:
+      if (to_match_2 < str_len_1) {
+        if (arg1[to_match_2] == 98) {
+          to_match_2 = to_match_2 + 1;
+          goto label0;
+        } 
+        if (arg1[to_match_2] == 99) {
+          label1:
+          to_match_2 = to_match_2 + 1;
+          if (to_match_2 < str_len_1) {
+            if (arg1[to_match_2] == 99) {
+              goto label1;
+            } 
+            if (arg1[to_match_2] == 100) {
+              to_match_2 = to_match_2 + 1;
+              if (to_match_2 < str_len_1) {
+                var3 = 0;
+                return var3;
+              } else {
+                var4 = 1;
+                return var4;
+              }
+            } else {
+              var3 = 0;
+              return var3;
+            }
+          } else {
+            var5 = 0;
+            return var5;
+          }
+        } else {
+          if (arg1[to_match_2] == 100) {
+            to_match_2 = to_match_2 + 1;
+            if (to_match_2 < str_len_1) {
+              var3 = 0;
+              return var3;
+            } else {
+              var4 = 1;
+              return var4;
+            }
+          } else {
+            var3 = 0;
+            return var3;
+          }
+        }
+      } else {
+        var5 = 0;
+        return var5;
+      }
+    } else {
+      var3 = 0;
+      return var3;
+    }
+  } else {
+    var5 = 0;
+    return var5;
+  }
+}
+

--- a/samples/outputs/sample40
+++ b/samples/outputs/sample40
@@ -3,26 +3,25 @@ int match_re (char* arg1) {
   int var3;
   int var4;
   int var5;
-  char* var0 = arg1;
-  int var1 = strlen(var0);
+  int var1 = strlen(arg1);
   int var2 = 0;
   if (var2 < var1) {
-    if (var0[var2] == 97) {
+    if (arg1[var2] == 97) {
       var2 = var2 + 1;
       label0:
       if (var2 < var1) {
-        if (var0[var2] == 98) {
+        if (arg1[var2] == 98) {
           var2 = var2 + 1;
           goto label0;
         } 
-        if (var0[var2] == 99) {
+        if (arg1[var2] == 99) {
           label1:
           var2 = var2 + 1;
           if (var2 < var1) {
-            if (var0[var2] == 99) {
+            if (arg1[var2] == 99) {
               goto label1;
             } 
-            if (var0[var2] == 100) {
+            if (arg1[var2] == 100) {
               var2 = var2 + 1;
               if (var2 < var1) {
                 var3 = 0;
@@ -40,7 +39,7 @@ int match_re (char* arg1) {
             return var5;
           }
         } else {
-          if (var0[var2] == 100) {
+          if (arg1[var2] == 100) {
             var2 = var2 + 1;
             if (var2 < var1) {
               var3 = 0;

--- a/samples/outputs/sample40
+++ b/samples/outputs/sample40
@@ -1,0 +1,70 @@
+#include <string.h>
+int match_re (char* arg1) {
+  int var3;
+  int var4;
+  int var5;
+  char* var0 = arg1;
+  int var1 = strlen(var0);
+  int var2 = 0;
+  if (var2 < var1) {
+    if (var0[var2] == 97) {
+      var2 = var2 + 1;
+      label0:
+      if (var2 < var1) {
+        if (var0[var2] == 98) {
+          var2 = var2 + 1;
+          goto label0;
+        } 
+        if (var0[var2] == 99) {
+          label1:
+          var2 = var2 + 1;
+          if (var2 < var1) {
+            if (var0[var2] == 99) {
+              goto label1;
+            } 
+            if (var0[var2] == 100) {
+              var2 = var2 + 1;
+              if (var2 < var1) {
+                var3 = 0;
+                return var3;
+              } else {
+                var4 = 1;
+                return var4;
+              }
+            } else {
+              var3 = 0;
+              return var3;
+            }
+          } else {
+            var5 = 0;
+            return var5;
+          }
+        } else {
+          if (var0[var2] == 100) {
+            var2 = var2 + 1;
+            if (var2 < var1) {
+              var3 = 0;
+              return var3;
+            } else {
+              var4 = 1;
+              return var4;
+            }
+          } else {
+            var3 = 0;
+            return var3;
+          }
+        }
+      } else {
+        var5 = 0;
+        return var5;
+      }
+    } else {
+      var3 = 0;
+      return var3;
+    }
+  } else {
+    var5 = 0;
+    return var5;
+  }
+}
+

--- a/samples/sample39.cpp
+++ b/samples/sample39.cpp
@@ -1,0 +1,45 @@
+// Include the headers
+#include "blocks/c_code_generator.h"
+#include "builder/static_var.h"
+#include "builder/dyn_var.h"
+#include "blocks/extract_cuda.h"
+#include <iostream>
+template <typename T>
+void resize(T &t, int size) {block::to<block::array_type>(t.block_var->var_type)->size = size;}
+
+// Include the BuildIt types
+using builder::dyn_var;
+using builder::static_var;
+
+static dyn_var<int> choose(dyn_var<int> n, dyn_var<int> k, const int MAX_N) {
+        int comp[MAX_N][MAX_N];
+        for (int i = 0; i < MAX_N; i++) {
+                comp[i][0] = 1;
+                comp[i][i] = 1;
+        }
+        for (int i = 1; i < MAX_N; ++i) {
+                comp[0][i] = 0;
+                for (int j = 1; j < i; ++j) {
+                        comp[i][j] = comp[i-1][j-1] + comp[i-1][j];
+                        comp[j][i] = 0;
+                }
+        }
+        dyn_var<int[]> comp_r;
+        resize(comp_r, MAX_N * MAX_N);
+        
+        for (static_var<int> i = 0; i < MAX_N * MAX_N; i++) {
+                builder::annotate("roll.0");
+                comp_r[i] = comp[i / MAX_N][i % MAX_N];
+        }
+        return comp_r[n * MAX_N + k];
+}
+
+int main(int argc, char* argv[]) {
+        builder::builder_context context;
+        auto ast = context.extract_function_ast(choose, "choose", 10);
+        
+        std::cout << "#include <iostream>" << std::endl;
+        block::c_code_generator::generate_code(ast, std::cout, 0);
+        std::cout << "int main(int argc, char* argv[]) {\n\tstd::cout << choose(8, 3) << std::endl;\n}" << std::endl;
+        
+}

--- a/samples/sample39.cpp
+++ b/samples/sample39.cpp
@@ -1,3 +1,4 @@
+/*NO_TEST*/
 // Include the headers
 #include "blocks/c_code_generator.h"
 #include "builder/static_var.h"

--- a/samples/sample40.cpp
+++ b/samples/sample40.cpp
@@ -1,0 +1,110 @@
+#include <iostream>
+#include <cstring>
+#include "builder/dyn_var.h"
+#include "builder/static_var.h"
+#include "blocks/c_code_generator.h"
+
+template <typename T>
+using dyn = builder::dyn_var<T>;
+using builder::static_var;
+
+static dyn<int (char*)> d_strlen(builder::with_name("strlen"));
+
+static bool is_normal(char m) {
+	return (m >= 'a' && m <= 'z') || (m >= 'A'
+		&& m <= 'Z') || (m >= '0' && m <= '9');
+}
+static void progress(const char *re, static_var<char> *next, int p) {
+	int ns = p + 1;
+	if ((int)strlen(re) == ns) {
+		next[ns] = true;
+	} else if (is_normal(re[ns])
+			|| '.' == re[ns]) {
+		next[ns] = true;
+		if ('*' == re[ns+1]) {
+			// We are allowed to skip this
+			// so just progress again
+			progress(re, next, ns+1);
+		}
+	} else if ('*' == re[ns]) {
+		next[p] = true;
+		progress(re, next, ns);
+	}
+}
+
+
+static dyn<int> match_regex(const char* re, dyn<char*> str) {
+	// allocate two state vectors
+	const int re_len = strlen(re);
+	static_var<char> *current = new static_var<char>[re_len + 1];
+	static_var<char> *next = new static_var<char>[re_len + 1];
+	for (static_var<int> i = 0; i < re_len + 1; i++)
+		current[i] = next[i] = 0;
+	progress(re, current, -1);
+	dyn<int> str_len = d_strlen(str);
+	dyn<int> to_match = 0;
+	while (to_match < str_len) {
+		// Don’t do anything for $.
+		static_var<int> early_break = -1;
+		for (static_var<int> state = 0; state < re_len; ++state)
+			if (current[state]) {
+				static_var<char> m = re[state];
+				if (is_normal(m)) {
+					if (-1 == early_break) {
+						// Normal character
+						if (str[to_match] == m) {
+							progress(re, next, state);
+							// If a match happens, it
+							// cannot match anything else
+							// Setting early break
+							// avoids unnecessary checks
+							early_break = m;
+						}
+					} else if (early_break == m) {
+						// The comparison has been done
+						// already, let us not repeat
+						progress(re, next, state);
+					}
+				} else if ('.' == m) {
+					progress(re, next, state);
+				} else {
+					printf("Invalid Character(%c)\n", (char)m);
+					return false;
+				}
+			}
+
+		// All the states have been checked
+		// Now swap the states and clear next
+		static_var<int> count = 0;
+		for (static_var<int> i = 0; i < re_len + 1; i++) {
+			current[i] = next[i];
+			next[i] = false;
+			if (current[i])
+				count++;
+		}
+		if (count == 0)
+			return false;
+		to_match = to_match + 1;
+	}
+	// Now that the string is done,
+	// we should have $ in the state
+	static_var<int> is_match = (char)current[re_len];
+	for (static_var<int> i = 0; i < re_len + 1; i++) {
+		next[i] = 0;
+		current[i] = 0;
+	}
+	return is_match;
+}
+
+
+
+int main(int argc, char* argv[]) {
+	builder::builder_context context;
+	context.feature_unstructured = true;
+	context.run_rce = true;
+	auto ast = context.extract_function_ast(match_regex,
+			"match_re", "ab*c*d");
+	std::cout << "#include <string.h>" << std::endl;
+	block::c_code_generator::generate_code(ast, std::cout);
+	return 0;
+}


### PR DESCRIPTION
This pull request implements a new feature for generating unstructured code and a corresponding context switch. Generally when BuildIt sees a static tag it has seen before it throws a Memoization Exception. This exception is caught and the code from the other execution is copied over. This sometimes leads to blow up and in some corner cases leads to incorrect variable names (can be fixed by hoisting those variables). But this change creates a flag which when set just inserts a goto instead of trying to copy the code when a Memoization Exception is caught. The flag also disables the loop related passes.

This PR also adds sample40 which tests this feature and implements the regex compiler from the CGO2022 paper. 

Finally, this change also adds a new compile_function_with_ast function to builder_dynamic.h which allows passing preconfigured context objects. 