### PR TITLE
Allow memoization table to remember statements inside sub-ifs 

### DIFF
--- a/include/builder/builder_dynamic.h
+++ b/include/builder/builder_dynamic.h
@@ -45,7 +45,7 @@ auto compile_function_with_context(builder_context context, FT f, ArgsT...args) 
 		compiler_name = COMPILER_PATH;
 	else {
 		compiler_name = CXX_COMPILER_PATH;
-		compiler_name += " -std=c++11";
+		compiler_name += " -std=c++11 -fPIC ";
 	}
 
 	std::string compile_command = compiler_name + " -shared -O3 " + source_name + " -o " + compiled_name;

--- a/samples/outputs.var_names/sample40
+++ b/samples/outputs.var_names/sample40
@@ -1,7 +1,6 @@
 #include <string.h>
 int match_re (char* arg1) {
   int var3;
-  int var4;
   int var5;
   int str_len_1 = strlen(arg1);
   int to_match_2 = 0;
@@ -22,13 +21,13 @@ int match_re (char* arg1) {
               goto label1;
             } 
             if (arg1[to_match_2] == 100) {
+              label2:
               to_match_2 = to_match_2 + 1;
               if (to_match_2 < str_len_1) {
                 var3 = 0;
                 return var3;
               } else {
-                var4 = 1;
-                return var4;
+                return 1;
               }
             } else {
               var3 = 0;
@@ -40,18 +39,10 @@ int match_re (char* arg1) {
           }
         } else {
           if (arg1[to_match_2] == 100) {
-            to_match_2 = to_match_2 + 1;
-            if (to_match_2 < str_len_1) {
-              var3 = 0;
-              return var3;
-            } else {
-              var4 = 1;
-              return var4;
-            }
-          } else {
-            var3 = 0;
-            return var3;
-          }
+            goto label2;
+          } 
+          var3 = 0;
+          return var3;
         }
       } else {
         var5 = 0;

--- a/samples/outputs/sample40
+++ b/samples/outputs/sample40
@@ -1,7 +1,6 @@
 #include <string.h>
 int match_re (char* arg1) {
   int var3;
-  int var4;
   int var5;
   int var1 = strlen(arg1);
   int var2 = 0;
@@ -22,13 +21,13 @@ int match_re (char* arg1) {
               goto label1;
             } 
             if (arg1[var2] == 100) {
+              label2:
               var2 = var2 + 1;
               if (var2 < var1) {
                 var3 = 0;
                 return var3;
               } else {
-                var4 = 1;
-                return var4;
+                return 1;
               }
             } else {
               var3 = 0;
@@ -40,18 +39,10 @@ int match_re (char* arg1) {
           }
         } else {
           if (arg1[var2] == 100) {
-            var2 = var2 + 1;
-            if (var2 < var1) {
-              var3 = 0;
-              return var3;
-            } else {
-              var4 = 1;
-              return var4;
-            }
-          } else {
-            var3 = 0;
-            return var3;
-          }
+            goto label2;
+          } 
+          var3 = 0;
+          return var3;
         }
       } else {
         var5 = 0;


### PR DESCRIPTION
Usually when the memoization table is updated at the end of each extraction, all the statements inside if statements are removed from the memoization table. This is because of the way we store the memoization table. It is a pointer to the parent block. 
We have to remove it because for the case of if stmts, the then/else block doesn't contain all the statements. There might be statements after the if. This is generally okay. 

But when feature_unstructured is enabled, this interferes with the optimization and a lot of code is duplicated. Fortunately, for unstructured we don't need all the statements. We just need to know the existence of the statement and the one statement. Because we are basically just inserting a goto. 

So this change, adds the sub statements inside the memoization table when feature_unstructured is enabled. This avoid a lot of code blowup (232k -> 728 lines for a regex example). 
