### PR TITLE
Fixed return_stmt to get a different unique tag

### DIFF
--- a/src/builder/builder.cpp
+++ b/src/builder/builder.cpp
@@ -31,7 +31,11 @@ void create_return_stmt(const builder &a) {
 		return;
 	block::return_stmt::Ptr ret_stmt =
 	    std::make_shared<block::return_stmt>();
-	ret_stmt->static_offset = a.block_expr->static_offset;
+	//ret_stmt->static_offset = a.block_expr->static_offset;
+	// Finding conflicts between return statements is somehow really hard. 
+	// So treat each return statement as different. This is okay, because a 
+	// jump is as bad a return. Also no performance issues
+	ret_stmt->static_offset = tracer::get_unique_tag();
 	ret_stmt->return_val = a.block_expr;
 	builder_context::current_builder_context->add_stmt_to_current_block(
 	    ret_stmt);


### PR DESCRIPTION
When we create return statements from function returns, we just copied over the static_offset from the expression. Unfortunately, for some reason it is hard to detect returns that are different. 

We fix this by assigning each return a different unique tag. This should be fine and not interfere with any memoization. Worst case we end up adding returns a bunch of times. 

This can be further cleaned up separately if necessary. 