### PR TITLE
Added support for caching variable names based on static tags

### DIFF
--- a/include/builder/dyn_var.h
+++ b/include/builder/dyn_var.h
@@ -147,9 +147,9 @@ public:
 		builder_context::current_builder_context->commit_uncommitted();
 		block::var::Ptr dyn_var = std::make_shared<block::var>();
 		dyn_var->var_type = create_block_type();
-		dyn_var->preferred_name = util::find_variable_name(this);
-		block_var = dyn_var;
 		tracer::tag offset = get_offset_in_function();
+		dyn_var->preferred_name = util::find_variable_name_cached(this, offset.stringify());
+		block_var = dyn_var;
 		dyn_var->static_offset = offset;
 		block_decl_stmt = nullptr;
 		if (builder_context::current_builder_context->bool_vector.size() > 0)

--- a/include/util/var_finder.h
+++ b/include/util/var_finder.h
@@ -3,6 +3,7 @@
 #include <string>
 namespace util {
 std::string find_variable_name(void*);
+std::string find_variable_name_cached(void*, std::string tag_string);
 }
 
 #endif

--- a/src/util/var_finder.cpp
+++ b/src/util/var_finder.cpp
@@ -1,6 +1,7 @@
 #include "util/var_finder.h"
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
+#include <map>
 
 #ifdef RECOVER_VAR_NAMES
 #define UNW_LOCAL_ONLY

--- a/src/util/var_finder.cpp
+++ b/src/util/var_finder.cpp
@@ -406,3 +406,17 @@ std::string find_variable_name(void* addr) {
 }
 }
 #endif
+
+namespace util {
+static std::map<std::string, std::string> tag_var_name_map;
+std::string find_variable_name_cached(void* addr, std::string tag_string) {
+	if (tag_var_name_map.find(tag_string) != tag_var_name_map.end()) {
+		return tag_var_name_map[tag_string];
+	}
+	
+	std::string ret = find_variable_name(addr);
+	if (ret != "")
+		tag_var_name_map[tag_string] = ret;
+	return ret;
+}
+}


### PR DESCRIPTION
When using RECOVER_VAR_NAMES=1, the cost of looking up variable names from the dwarf info is quite high. But two variables with the same static tag will always have the same name. So we can cache names based on tags. 

This PR implements the feature and improves performance significantly. 