### PR TITLE
Added basic support for dyn_arr type

### DIFF
--- a/include/builder/array.h
+++ b/include/builder/array.h
@@ -1,0 +1,70 @@
+#ifndef BUILDER_ARRAY_H
+#define BUILDER_ARRAY_H
+#include "builder/dyn_var.h"
+#include "builder/static_var.h"
+
+namespace builder {
+
+template <typename T, size_t size = 0> 
+class dyn_arr {
+private:
+	dyn_var<T>* m_arr = nullptr;
+	size_t actual_size = 0;
+public:
+
+	dyn_arr() {
+		if (size) {
+			actual_size = size;
+			m_arr = (dyn_var<T>*) new char[sizeof(dyn_var<T>) * actual_size];
+			for (static_var<size_t> i = 0; i < actual_size; i++) {
+				new (m_arr + i) dyn_var<T>();
+			}
+		}
+	}
+	dyn_arr(const std::initializer_list<builder>& init) {
+		if (size) {
+			actual_size = size;		
+		} else {
+			actual_size = init.size();
+		}
+		m_arr = (dyn_var<T>*) new char[sizeof(dyn_var<T>) * actual_size];
+		for (static_var<size_t> i = 0; i < actual_size; i++) {
+			new (m_arr + i) dyn_var<T>(*(init.begin() + i));
+		}
+	}
+	void set_size(size_t new_size) {
+		assert(size == 0 && "set_size should be only called for dyn_arr without size");
+		assert(m_arr == nullptr && "set_size should be only called once");
+		actual_size = new_size;
+		m_arr = (dyn_var<T>*) new char[sizeof(dyn_var<T>) * actual_size];
+		for (static_var<size_t> i = 0; i < actual_size; i++) {
+			new (m_arr + i) dyn_var<T>();
+		}
+	}
+
+	dyn_arr(const dyn_arr& other) = delete;
+	dyn_arr& operator= (const dyn_arr& other) = delete;
+
+	dyn_var<T>& operator[](size_t index) {
+		assert(m_arr != nullptr && "Should call set_size for arrays that don't have a size");
+		return m_arr[index];
+	}
+	const dyn_var<T>& operator[] (size_t index) const {
+		assert(m_arr != nullptr && "Should call set_size for arrays that don't have a size");
+		return m_arr[index];
+	}
+
+	~dyn_arr() {
+		if (m_arr) {
+			for (static_var<size_t> i = 0; i < actual_size; i++) {
+				m_arr[i].~dyn_var<T>();
+			}
+			
+			delete[] (char*)m_arr;
+		}
+	}
+};
+
+}
+
+#endif

--- a/samples/outputs.var_names/sample43
+++ b/samples/outputs.var_names/sample43
@@ -1,0 +1,17 @@
+void foo (void) {
+  int var0;
+  int var1;
+  int var2;
+  var0 = 1;
+  var1 = var0 + 2;
+  var2 = var1 + var0;
+  int var3 = 0;
+  int var4 = var0 + 4;
+  int var5 = 0;
+  int var6 = 0;
+  int var7 = 1;
+  int var8 = 2;
+  int var9;
+  int var10;
+}
+

--- a/samples/outputs/sample43
+++ b/samples/outputs/sample43
@@ -1,0 +1,17 @@
+void foo (void) {
+  int var0;
+  int var1;
+  int var2;
+  var0 = 1;
+  var1 = var0 + 2;
+  var2 = var1 + var0;
+  int var3 = 0;
+  int var4 = var0 + 4;
+  int var5 = 0;
+  int var6 = 0;
+  int var7 = 1;
+  int var8 = 2;
+  int var9;
+  int var10;
+}
+

--- a/samples/sample43.cpp
+++ b/samples/sample43.cpp
@@ -1,0 +1,26 @@
+#include "builder/dyn_var.h"
+#include "blocks/c_code_generator.h"
+#include "builder/array.h"
+
+using builder::dyn_var;
+using builder::dyn_arr;
+using namespace std;
+
+static void foo() {
+	dyn_arr<int, 3> x;
+	x[0] = 1;
+	x[1] = x[0] + 2;
+	x[2] = x[1] + x[0];
+	
+	dyn_arr<int, 4> y = {0, x[0] + 4, 0, 0};
+
+	dyn_arr<int> z = {1, 2};
+	
+	dyn_arr<int> a;
+	a.set_size(2);
+}
+int main(int argc, char* argv[]) {
+	auto ast = builder::builder_context().extract_function_ast(foo, "foo");
+	block::c_code_generator::generate_code(ast, cout, 0);
+	return 0;
+}


### PR DESCRIPTION
This PR adds basic support for dyn_arr<T, N> which serve the purpose of dyn_arr<T>[N]. The reason these are required is so that the constructors can be called in a loop with static_var index. A normal array declaration would just produce a infinite while loop. 

The dyn_arr has its copy constructor and assignment operator deleted. 