### PR TITLE
Added a copy constructor for dyn_arr that performs a deep copy

### DIFF
--- a/include/builder/array.h
+++ b/include/builder/array.h
@@ -29,7 +29,10 @@ public:
 		}
 		m_arr = (dyn_var<T>*) new char[sizeof(dyn_var<T>) * actual_size];
 		for (static_var<size_t> i = 0; i < actual_size; i++) {
-			new (m_arr + i) dyn_var<T>(*(init.begin() + i));
+			if (i < init.size()) 
+				new (m_arr + i) dyn_var<T>(*(init.begin() + i));
+			else
+				new (m_arr + i) dyn_var<T>();
 		}
 	}
 	void set_size(size_t new_size) {
@@ -42,7 +45,31 @@ public:
 		}
 	}
 
-	dyn_arr(const dyn_arr& other) = delete;
+	template <typename T2, size_t N>
+	void initialize_from_other(const dyn_arr<T2, N>& other) {
+		if (size) {
+			actual_size = size;
+		} else {
+			actual_size = other.actual_size;
+		}
+		m_arr = (dyn_var<T>*) new char[sizeof(dyn_var<T>) * actual_size];
+		for (static_var<size_t> i = 0; i < actual_size; i++) {
+			if (i < other.actual_size) 
+				new (m_arr + i) dyn_var<T>(other[i]);
+			else 
+				new (m_arr + i) dyn_var<T>();
+		}
+
+	}
+
+	dyn_arr (const dyn_arr& other) {
+		initialize_from_other(other);	
+	}	
+	template <typename T2, size_t N>	
+	dyn_arr(const dyn_arr<T2, N>& other) {
+		initialize_from_other(other);
+	}
+
 	dyn_arr& operator= (const dyn_arr& other) = delete;
 
 	dyn_var<T>& operator[](size_t index) {
@@ -63,6 +90,9 @@ public:
 			delete[] (char*)m_arr;
 		}
 	}
+
+	template <typename T2, size_t N> 
+	friend class dyn_arr;
 };
 
 }

--- a/samples/outputs.var_names/sample43
+++ b/samples/outputs.var_names/sample43
@@ -13,5 +13,14 @@ void foo (void) {
   int var8 = 2;
   int var9;
   int var10;
+  int var11 = var3;
+  int var12 = var4;
+  int var13 = var5;
+  int var14 = var6;
+  int var15 = var9;
+  int var16 = var10;
+  int var17;
+  int var18;
+  int var19;
 }
 

--- a/samples/outputs/sample43
+++ b/samples/outputs/sample43
@@ -13,5 +13,14 @@ void foo (void) {
   int var8 = 2;
   int var9;
   int var10;
+  int var11 = var3;
+  int var12 = var4;
+  int var13 = var5;
+  int var14 = var6;
+  int var15 = var9;
+  int var16 = var10;
+  int var17;
+  int var18;
+  int var19;
 }
 

--- a/samples/sample43.cpp
+++ b/samples/sample43.cpp
@@ -18,6 +18,11 @@ static void foo() {
 	
 	dyn_arr<int> a;
 	a.set_size(2);
+
+
+	dyn_arr<int> b = y;
+	dyn_arr<int, 5> c = a;
+	
 }
 int main(int argc, char* argv[]) {
 	auto ast = builder::builder_context().extract_function_ast(foo, "foo");


### PR DESCRIPTION
This PR adds a copy constructor to dyn_arr that deep copy (constructs) all the internal dyn_vars. This is useful because this allows the RCE pass to eliminate these copies if necessary. 