### PR TITLE
Made the template types for custom types explicit

### DIFF
--- a/include/builder/block_type_extractor.h
+++ b/include/builder/block_type_extractor.h
@@ -18,6 +18,7 @@ public:
 		static_assert(std::is_base_of<custom_type_base, T>::value, "Custom types should inherit from builder::custom_type_base");
 		block::named_type::Ptr type = std::make_shared<block::named_type>();
 		type->type_name = T::type_name;
+		type->template_args = T::get_template_arg_types();
 		return type;	
 		
 	}
@@ -273,22 +274,6 @@ public:
 		type->type_name = N;
 		type->template_args = extract_type_from_args<Args...>::get_types();
 		return type;	
-	}
-};
-
-template <template <typename...> class T, typename...Args>
-class type_extractor<T<Args...>> {
-public:
-	// This implementation is currenty only used 
-	// by custom types which are derived from custom_type_base
-	// AND have template arguments
-	static block::type::Ptr extract_type(void) {
-		static_assert(std::is_base_of<custom_type_base, T<Args...>>::value, "Custom types should inherit from builder::custom_type_base");
-		block::named_type::Ptr type = std::make_shared<block::named_type>();
-		type->type_name = T<Args...>::type_name;
-		type->template_args = extract_type_from_args<Args...>::get_types();
-		return type;	
-		
 	}
 };
 

--- a/include/builder/dyn_var.h
+++ b/include/builder/dyn_var.h
@@ -45,7 +45,17 @@ public:
 
 };
 
-struct custom_type_base {
+struct custom_type_base {	
+	static std::vector<block::type::Ptr> get_template_arg_types() {
+		return extract_type_from_args<>::get_types();
+	}
+};
+
+template <typename...Args>
+struct custom_type: custom_type_base {
+	static std::vector<block::type::Ptr> get_template_arg_types() {
+		return extract_type_from_args<Args...>::get_types();
+	}
 };
 
 // Struct to initialize a dyn_var as member;

--- a/samples/sample46.cpp
+++ b/samples/sample46.cpp
@@ -10,20 +10,20 @@ using builder::as_member_of;
 
 
 
-struct FooT: public builder::custom_type_base {
+struct FooT: public builder::custom_type<> {
 	static constexpr const char* type_name = "FooT";
 	dyn_var<int> member = as_member_of(this, "member");
 };
 
 template <typename T>
-struct BarT: public builder::custom_type_base {
+struct BarT: public builder::custom_type<T> {
 	static constexpr const char* type_name = "BarT";
 	dyn_var<int> my_member = as_member_of(this, "my_member");
 	dyn_var<int> second_member = as_member_of(this, "second_member");
 };
 
 template <typename T1, typename T2>
-struct CarT: public builder::custom_type_base {
+struct CarT: public builder::custom_type<T1, T2> {
 	static constexpr const char* type_name = "CarT";
 	dyn_var<int> my_member = as_member_of(this, "my_member");
 };


### PR DESCRIPTION
This is a small change to the custom type API. The template arguments that need to be in the generated code, now need to be explicitly forwarded instead of being implicitly all generated. This allows control over which template arguments are actually for the second stage code. 