### PR TITLE
Renamed as_member_of to as_member and removed the parent argument

### DIFF
--- a/samples/sample31.cpp
+++ b/samples/sample31.cpp
@@ -6,7 +6,7 @@
 #include <iostream>
 
 using builder::dyn_var;
-using builder::as_member_of;
+using builder::as_member;
 // We will now create our own dyn_var type with members
 template <typename T>
 struct my_dyn_var: public dyn_var<T> {
@@ -23,8 +23,8 @@ struct my_dyn_var: public dyn_var<T> {
 	builder::builder operator=(const my_dyn_var &t) {
 		return (*this) = (builder::builder)t;
 	}	
-	dyn_var<int> var1 = as_member_of(this, "var1");	
-	dyn_var<int> neighbor = as_member_of(this, "neighbor");	
+	dyn_var<int> var1 = as_member(this, "var1");	
+	dyn_var<int> neighbor = as_member(this, "neighbor");	
 };
 
 int main(int argc, char *argv[]) {

--- a/samples/sample33.cpp
+++ b/samples/sample33.cpp
@@ -6,7 +6,7 @@
 #include <iostream>
 using builder::dyn_var;
 using builder::static_var;
-using builder::as_member_of;
+using builder::as_member;
 
 constexpr char foo_t_name[] = "FooT";
 using foo_t = typename builder::name<foo_t_name>;
@@ -22,7 +22,7 @@ public:
 		return (*this) = (builder::builder)t;
 	}	
 
-	dyn_var<int> member = as_member_of(this, "member");
+	dyn_var<int> member = as_member(this, "member");
 };
 
 

--- a/samples/sample38.cpp
+++ b/samples/sample38.cpp
@@ -7,7 +7,7 @@
 #include <memory>
 using builder::dyn_var;
 using builder::static_var;
-using builder::as_member_of;
+using builder::as_member;
 
 constexpr char foo_t_name[] = "FooT";
 using foo_t = typename builder::name<foo_t_name>;
@@ -27,7 +27,7 @@ public:
 	dyn_var(const dyn_var& t): dyn_var_impl((builder)t){}
 	dyn_var(): dyn_var_impl<foo_t>() {}
 
-	dyn_var<int> member = as_member_of(this, "member");
+	dyn_var<int> member = as_member(this, "member");
 };
 
 // Create specialization for foo_t* so that we can overload the * operator
@@ -52,7 +52,7 @@ public:
 	// This is POC of how -> operator can
 	// be implemented. Requires the hack of creating a dummy 
 	// member because -> needs to return a pointer. 
-	dyn_var<foo_t> _p = as_member_of(this, "_p");
+	dyn_var<foo_t> _p = as_member(this, "_p");
 	dyn_var<foo_t>* operator->() {
 		_p = (cast)this->operator[](0);
 		return _p.addr();

--- a/samples/sample46.cpp
+++ b/samples/sample46.cpp
@@ -6,26 +6,26 @@
 #include <iostream>
 using builder::dyn_var;
 using builder::static_var;
-using builder::as_member_of;
+using builder::as_member;
 
 
 
 struct FooT: public builder::custom_type<> {
 	static constexpr const char* type_name = "FooT";
-	dyn_var<int> member = as_member_of(this, "member");
+	dyn_var<int> member = as_member("member");
 };
 
 template <typename T>
 struct BarT: public builder::custom_type<T> {
 	static constexpr const char* type_name = "BarT";
-	dyn_var<int> my_member = as_member_of(this, "my_member");
-	dyn_var<int> second_member = as_member_of(this, "second_member");
+	dyn_var<int> my_member = as_member("my_member");
+	dyn_var<int> second_member = as_member("second_member");
 };
 
 template <typename T1, typename T2>
 struct CarT: public builder::custom_type<T1, T2> {
 	static constexpr const char* type_name = "CarT";
-	dyn_var<int> my_member = as_member_of(this, "my_member");
+	dyn_var<int> my_member = as_member("my_member");
 };
 
 static void bar(void) {


### PR DESCRIPTION
When using custom_type API, as_member_of (now renamed to as_member) doesn't require the parent var pointer. The parent can be implicitly registered by constructors. 