### PR TITLE
Added support to generate struct decls

### DIFF
--- a/include/blocks/c_code_generator.h
+++ b/include/blocks/c_code_generator.h
@@ -2,8 +2,8 @@
 #define C_CODE_GENERATOR_H
 #include "blocks/block_visitor.h"
 #include "blocks/stmt.h"
-#include "util/printer.h"
 #include "builder/dyn_var.h"
+#include "util/printer.h"
 #include <unordered_map>
 #include <unordered_set>
 
@@ -89,16 +89,17 @@ public:
 		printer::indent(oss, indent);
 		auto var_type = T::create_block_type();
 		assert(isa<named_type>(var_type) && "Cannot create struct declarations for un-named types");
-		assert(to<named_type>(var_type)->template_args.size() == 0 && "Cannot yet, generate decls for types with template args");
-		oss << "struct " << to<named_type>(var_type)->type_name << " {\n";	
+		assert(to<named_type>(var_type)->template_args.size() == 0 &&
+		       "Cannot yet, generate decls for types with template args");
+		oss << "struct " << to<named_type>(var_type)->type_name << " {\n";
 		indent++;
-		
-		for (auto member: v.members) {
+
+		for (auto member : v.members) {
 			printer::indent(oss, indent);
 			auto decl = std::make_shared<decl_stmt>();
 			decl->decl_var = member->block_var;
-			decl->accept(&generator);	
-			oss << std::endl;	
+			decl->accept(&generator);
+			oss << std::endl;
 		}
 		indent--;
 		printer::indent(oss, indent);

--- a/include/builder/dyn_var.h
+++ b/include/builder/dyn_var.h
@@ -6,7 +6,7 @@
 namespace builder {
 
 namespace options {
-	extern bool track_members;
+extern bool track_members;
 }
 
 class var {
@@ -34,8 +34,7 @@ public:
 	block::expr::Ptr encompassing_expr;
 
 	// Feature to gather members of this type
-	std::vector<var*> members;
-
+	std::vector<var *> members;
 
 	static block::type::Ptr create_block_type(void) {
 		// Cannot create block type for abstract class

--- a/include/builder/dyn_var.h
+++ b/include/builder/dyn_var.h
@@ -5,6 +5,10 @@
 #include "util/var_finder.h"
 namespace builder {
 
+namespace options {
+	extern bool track_members;
+}
+
 class var {
 public:
 	enum var_state {
@@ -28,6 +32,10 @@ public:
 	// type derived from dyn_var, mainly for using members
 	// Avoid using this unless really required
 	block::expr::Ptr encompassing_expr;
+
+	// Feature to gather members of this type
+	std::vector<var*> members;
+
 
 	static block::type::Ptr create_block_type(void) {
 		// Cannot create block type for abstract class
@@ -223,6 +231,13 @@ public:
 		var_name = a.member_name;
 		block_var = nullptr;
 		block_decl_stmt = nullptr;
+
+		if (options::track_members) {
+			parent_var->members.push_back(this);
+			block_var = std::make_shared<block::var>();
+			block_var->var_type = create_block_type();
+			block_var->var_name = var_name;
+		}
 	}
 	// Constructor and operator = to initialize a dyn_var as a compound expr
 	// This declaration also does not produce a declaration or assign stmt

--- a/samples/outputs.var_names/sample46
+++ b/samples/outputs.var_names/sample46
@@ -1,70 +1,78 @@
-STMT_BLOCK
-  DECL_STMT
-    NAMED_TYPE (FooT)
-    VAR (g_0)
-    NO_INITIALIZATION
-  EXPR_STMT
-    ASSIGN_EXPR
-      VAR_EXPR
-        VAR (g_0)
-      PLUS_EXPR
-        VAR_EXPR
-          VAR (g_0)
-        INT_CONST (1)
-  DECL_STMT
-    SCALAR_TYPE (INT)
-    VAR (x_1)
-    MEMBER_ACCESS_EXPR (member)
-      VAR_EXPR
-        VAR (g_0)
-  DECL_STMT
-    NAMED_TYPE (FooT)
-    VAR (h_2)
-    VAR_EXPR
+FUNC_DECL
+  SCALAR_TYPE (VOID)
+  STMT_BLOCK
+    DECL_STMT
+      NAMED_TYPE (FooT)
       VAR (g_0)
-  EXPR_STMT
-    ASSIGN_EXPR
-      VAR_EXPR
-        VAR (h_2)
-      VAR_EXPR
-        VAR (g_0)
-  DECL_STMT
-    NAMED_TYPE (BarT)
-      SCALAR_TYPE (INT)
-    VAR (f_3)
-    NO_INITIALIZATION
-  EXPR_STMT
-    ASSIGN_EXPR
-      MEMBER_ACCESS_EXPR (second_member)
-        VAR_EXPR
-          VAR (f_3)
-      PLUS_EXPR
+      NO_INITIALIZATION
+    EXPR_STMT
+      ASSIGN_EXPR
         VAR_EXPR
           VAR (g_0)
-        INT_CONST (1)
-  DECL_STMT
-    NAMED_TYPE (CarT)
+        PLUS_EXPR
+          VAR_EXPR
+            VAR (g_0)
+          INT_CONST (1)
+    DECL_STMT
       SCALAR_TYPE (INT)
-      NAMED_TYPE (BarT)
-        SCALAR_TYPE (FLOAT)
-    VAR (l_4)
-    NO_INITIALIZATION
-  EXPR_STMT
-    ASSIGN_EXPR
-      MEMBER_ACCESS_EXPR (my_member)
-        VAR_EXPR
-          VAR (l_4)
+      VAR (x_1)
       MEMBER_ACCESS_EXPR (member)
         VAR_EXPR
           VAR (g_0)
-{
+    DECL_STMT
+      NAMED_TYPE (FooT)
+      VAR (h_2)
+      VAR_EXPR
+        VAR (g_0)
+    EXPR_STMT
+      ASSIGN_EXPR
+        VAR_EXPR
+          VAR (h_2)
+        VAR_EXPR
+          VAR (g_0)
+    DECL_STMT
+      NAMED_TYPE (BarT)
+      VAR (f_3)
+      NO_INITIALIZATION
+    EXPR_STMT
+      ASSIGN_EXPR
+        MEMBER_ACCESS_EXPR (second_member)
+          VAR_EXPR
+            VAR (f_3)
+        PLUS_EXPR
+          VAR_EXPR
+            VAR (g_0)
+          INT_CONST (1)
+    DECL_STMT
+      NAMED_TYPE (CarT)
+        SCALAR_TYPE (INT)
+        NAMED_TYPE (BarT)
+      VAR (l_4)
+      NO_INITIALIZATION
+    EXPR_STMT
+      ASSIGN_EXPR
+        MEMBER_ACCESS_EXPR (my_member)
+          VAR_EXPR
+            VAR (l_4)
+        MEMBER_ACCESS_EXPR (member)
+          VAR_EXPR
+            VAR (g_0)
+struct FooT {
+  int member;
+};
+struct BarT {
+  int my_member;
+  int second_member;
+};
+void my_bar (void) {
   FooT g_0;
   g_0 = g_0 + 1;
   int x_1 = g_0.member;
   FooT h_2 = g_0;
   h_2 = g_0;
-  BarT<int> f_3;
+  BarT f_3;
   f_3.second_member = g_0 + 1;
-  CarT<int, BarT<float>> l_4;
+  CarT<int, BarT> l_4;
   l_4.my_member = g_0.member;
 }
+

--- a/samples/outputs/sample46
+++ b/samples/outputs/sample46
@@ -1,70 +1,78 @@
-STMT_BLOCK
-  DECL_STMT
-    NAMED_TYPE (FooT)
-    VAR (var0)
-    NO_INITIALIZATION
-  EXPR_STMT
-    ASSIGN_EXPR
-      VAR_EXPR
-        VAR (var0)
-      PLUS_EXPR
-        VAR_EXPR
-          VAR (var0)
-        INT_CONST (1)
-  DECL_STMT
-    SCALAR_TYPE (INT)
-    VAR (var1)
-    MEMBER_ACCESS_EXPR (member)
-      VAR_EXPR
-        VAR (var0)
-  DECL_STMT
-    NAMED_TYPE (FooT)
-    VAR (var2)
-    VAR_EXPR
+FUNC_DECL
+  SCALAR_TYPE (VOID)
+  STMT_BLOCK
+    DECL_STMT
+      NAMED_TYPE (FooT)
       VAR (var0)
-  EXPR_STMT
-    ASSIGN_EXPR
-      VAR_EXPR
-        VAR (var2)
-      VAR_EXPR
-        VAR (var0)
-  DECL_STMT
-    NAMED_TYPE (BarT)
-      SCALAR_TYPE (INT)
-    VAR (var3)
-    NO_INITIALIZATION
-  EXPR_STMT
-    ASSIGN_EXPR
-      MEMBER_ACCESS_EXPR (second_member)
-        VAR_EXPR
-          VAR (var3)
-      PLUS_EXPR
+      NO_INITIALIZATION
+    EXPR_STMT
+      ASSIGN_EXPR
         VAR_EXPR
           VAR (var0)
-        INT_CONST (1)
-  DECL_STMT
-    NAMED_TYPE (CarT)
+        PLUS_EXPR
+          VAR_EXPR
+            VAR (var0)
+          INT_CONST (1)
+    DECL_STMT
       SCALAR_TYPE (INT)
-      NAMED_TYPE (BarT)
-        SCALAR_TYPE (FLOAT)
-    VAR (var4)
-    NO_INITIALIZATION
-  EXPR_STMT
-    ASSIGN_EXPR
-      MEMBER_ACCESS_EXPR (my_member)
-        VAR_EXPR
-          VAR (var4)
+      VAR (var1)
       MEMBER_ACCESS_EXPR (member)
         VAR_EXPR
           VAR (var0)
-{
+    DECL_STMT
+      NAMED_TYPE (FooT)
+      VAR (var2)
+      VAR_EXPR
+        VAR (var0)
+    EXPR_STMT
+      ASSIGN_EXPR
+        VAR_EXPR
+          VAR (var2)
+        VAR_EXPR
+          VAR (var0)
+    DECL_STMT
+      NAMED_TYPE (BarT)
+      VAR (var3)
+      NO_INITIALIZATION
+    EXPR_STMT
+      ASSIGN_EXPR
+        MEMBER_ACCESS_EXPR (second_member)
+          VAR_EXPR
+            VAR (var3)
+        PLUS_EXPR
+          VAR_EXPR
+            VAR (var0)
+          INT_CONST (1)
+    DECL_STMT
+      NAMED_TYPE (CarT)
+        SCALAR_TYPE (INT)
+        NAMED_TYPE (BarT)
+      VAR (var4)
+      NO_INITIALIZATION
+    EXPR_STMT
+      ASSIGN_EXPR
+        MEMBER_ACCESS_EXPR (my_member)
+          VAR_EXPR
+            VAR (var4)
+        MEMBER_ACCESS_EXPR (member)
+          VAR_EXPR
+            VAR (var0)
+struct FooT {
+  int member;
+};
+struct BarT {
+  int my_member;
+  int second_member;
+};
+void my_bar (void) {
   FooT var0;
   var0 = var0 + 1;
   int var1 = var0.member;
   FooT var2 = var0;
   var2 = var0;
-  BarT<int> var3;
+  BarT var3;
   var3.second_member = var0 + 1;
-  CarT<int, BarT<float>> var4;
+  CarT<int, BarT> var4;
   var4.my_member = var0.member;
 }
+

--- a/samples/sample46.cpp
+++ b/samples/sample46.cpp
@@ -14,16 +14,16 @@ struct FooT : public builder::custom_type<> {
 };
 
 template <typename T>
-struct BarT : public builder::custom_type<T> {
+struct BarT : public builder::custom_type<> {
 	static constexpr const char *type_name = "BarT";
-	dyn_var<int> my_member = as_member("my_member");
-	dyn_var<int> second_member = as_member("second_member");
+	dyn_var<T> my_member = as_member("my_member");
+	dyn_var<T> second_member = as_member("second_member");
 };
 
 template <typename T1, typename T2>
 struct CarT : public builder::custom_type<T1, T2> {
 	static constexpr const char *type_name = "CarT";
-	dyn_var<int> my_member = as_member("my_member");
+	dyn_var<T2> my_member = as_member("my_member");
 };
 
 static void bar(void) {
@@ -42,8 +42,15 @@ static void bar(void) {
 
 int main(int argc, char *argv[]) {
 	builder::builder_context context;
-	auto ast = context.extract_ast_from_function(bar);
+	auto ast = context.extract_function_ast(bar, "my_bar");
 	ast->dump(std::cout, 0);
+
+	block::c_code_generator::generate_struct_decl<dyn_var<FooT>>(std::cout);
+	block::c_code_generator::generate_struct_decl<dyn_var<BarT<int>>>(std::cout);
+
+	// Don't do this because this has a template in the generated type
+	// block::c_code_generator::generate_struct_decl<dyn_var<CarT<int, BarT<float>>>>(std::cout);
+
 	block::c_code_generator::generate_code(ast, std::cout, 0);
 	return 0;
 }

--- a/src/builder/builder.cpp
+++ b/src/builder/builder.cpp
@@ -5,7 +5,7 @@
 
 namespace builder {
 namespace options {
-	bool track_members = false;
+bool track_members = false;
 }
 
 template <>

--- a/src/builder/builder.cpp
+++ b/src/builder/builder.cpp
@@ -4,6 +4,9 @@
 #include "util/tracer.h"
 
 namespace builder {
+namespace options {
+	bool track_members = false;
+}
 
 template <>
 std::vector<block::type::Ptr> extract_type_vector_dyn<>(void) {


### PR DESCRIPTION
block::c_code_generator now has a new function generate_struct_decl that generates the definition for a custom type. Currently this only works for non-templated generated types. 
Sample 46 has been updated to demonstrate the usage. 