### PR TITLE
Implemented basic support for arrays of static_vars

### DIFF
--- a/include/builder/static_var.h
+++ b/include/builder/static_var.h
@@ -55,5 +55,67 @@ public:
 	}
 };
 
+template <typename T>
+class static_var<T[]> {
+	public: 
+	static_assert(std::is_same<T, short int>::value || std::is_same<T, unsigned short int>::value ||
+			  std::is_same<T, int>::value || std::is_same<T, unsigned int>::value ||
+			  std::is_same<T, long int>::value || std::is_same<T, unsigned long int>::value ||
+			  std::is_same<T, long long int>::value || std::is_same<T, unsigned long long int>::value ||
+			  std::is_same<T, char>::value || std::is_same<T, unsigned char>::value ||
+			  std::is_same<T, float>::value || std::is_same<T, double>::value || std::is_pointer<T>::value,
+		      "Currently builder::static_var arrays is only supported for basic types\n");
+	static_assert(sizeof(T) < MAX_TRACKING_VAR_SIZE, "Currently builder::static_var supports variables of max size "
+							 "= " TOSTRING(MAX_TRACKING_VARIABLE_SIZE));
+	// Disable copy-assignment and initialization
+	static_var(const static_var& x) = delete;	
+	static_var& operator= (const static_var& x) = delete;
+	T* val = nullptr;
+	
+	T& operator[] (size_t index) {
+		return val[index];
+	}
+	const T& operator[] (size_t index) const {
+		return val[index];
+	}
+	static_var() {
+		assert(builder_context::current_builder_context != nullptr);
+		// This val _should_ not be used. But we will insert it to hold place
+		// for this static var in the list of tuples, otherwise destructor order will be weird
+		val = new T[1];
+		
+		builder_context::current_builder_context->static_var_tuples.push_back(
+		    tracking_tuple((unsigned char*)val, 1));
+	}
+	static_var(const std::initializer_list<T> &list) {
+		assert(builder_context::current_builder_context != nullptr);
+		val = new T[list.size()];
+		builder_context::current_builder_context->static_var_tuples.push_back(
+		    tracking_tuple((unsigned char*)val, sizeof(T) * list.size()));
+		for (int i = 0; i < list.size(); i++) {
+			val[i] = list[i];
+		}
+	}
+	void resize(size_t s) {
+		T* new_ptr = new T[s];
+		assert(builder_context::current_builder_context != nullptr);
+		assert(builder_context::current_builder_context->static_var_tuples.size() > 0);
+		for (size_t i = 0; i < builder_context::current_builder_context->static_var_tuples.size(); i++) {
+			if (builder_context::current_builder_context->static_var_tuples[i].ptr == (unsigned char*)val) {
+				builder_context::current_builder_context->static_var_tuples[i] = tracking_tuple((unsigned char*)new_ptr, sizeof(T) * s);
+				break;
+			}
+		}
+		delete[] val;
+		val = new_ptr;
+	}
+	~static_var() {
+		assert(builder_context::current_builder_context != nullptr);
+		assert(builder_context::current_builder_context->static_var_tuples.size() > 0);
+		assert(builder_context::current_builder_context->static_var_tuples.back().ptr == (unsigned char *)val);
+		builder_context::current_builder_context->static_var_tuples.pop_back();
+		delete[] val;	
+	}
+};
 } // namespace builder
 #endif

--- a/include/builder/static_var.h
+++ b/include/builder/static_var.h
@@ -57,7 +57,7 @@ public:
 
 template <typename T>
 class static_var<T[]> {
-	public: 
+public:
 	static_assert(std::is_same<T, short int>::value || std::is_same<T, unsigned short int>::value ||
 			  std::is_same<T, int>::value || std::is_same<T, unsigned int>::value ||
 			  std::is_same<T, long int>::value || std::is_same<T, unsigned long int>::value ||
@@ -68,14 +68,14 @@ class static_var<T[]> {
 	static_assert(sizeof(T) < MAX_TRACKING_VAR_SIZE, "Currently builder::static_var supports variables of max size "
 							 "= " TOSTRING(MAX_TRACKING_VARIABLE_SIZE));
 	// Disable copy-assignment and initialization
-	static_var(const static_var& x) = delete;	
-	static_var& operator= (const static_var& x) = delete;
-	T* val = nullptr;
-	
-	T& operator[] (size_t index) {
+	static_var(const static_var &x) = delete;
+	static_var &operator=(const static_var &x) = delete;
+	T *val = nullptr;
+
+	T &operator[](size_t index) {
 		return val[index];
 	}
-	const T& operator[] (size_t index) const {
+	const T &operator[](size_t index) const {
 		return val[index];
 	}
 	static_var() {
@@ -83,26 +83,28 @@ class static_var<T[]> {
 		// This val _should_ not be used. But we will insert it to hold place
 		// for this static var in the list of tuples, otherwise destructor order will be weird
 		val = new T[1];
-		
+
 		builder_context::current_builder_context->static_var_tuples.push_back(
-		    tracking_tuple((unsigned char*)val, 1));
+		    tracking_tuple((unsigned char *)val, 1));
 	}
 	static_var(const std::initializer_list<T> &list) {
 		assert(builder_context::current_builder_context != nullptr);
 		val = new T[list.size()];
 		builder_context::current_builder_context->static_var_tuples.push_back(
-		    tracking_tuple((unsigned char*)val, sizeof(T) * list.size()));
+		    tracking_tuple((unsigned char *)val, sizeof(T) * list.size()));
 		for (int i = 0; i < list.size(); i++) {
 			val[i] = list[i];
 		}
 	}
 	void resize(size_t s) {
-		T* new_ptr = new T[s];
+		T *new_ptr = new T[s];
 		assert(builder_context::current_builder_context != nullptr);
 		assert(builder_context::current_builder_context->static_var_tuples.size() > 0);
 		for (size_t i = 0; i < builder_context::current_builder_context->static_var_tuples.size(); i++) {
-			if (builder_context::current_builder_context->static_var_tuples[i].ptr == (unsigned char*)val) {
-				builder_context::current_builder_context->static_var_tuples[i] = tracking_tuple((unsigned char*)new_ptr, sizeof(T) * s);
+			if (builder_context::current_builder_context->static_var_tuples[i].ptr ==
+			    (unsigned char *)val) {
+				builder_context::current_builder_context->static_var_tuples[i] =
+				    tracking_tuple((unsigned char *)new_ptr, sizeof(T) * s);
 				break;
 			}
 		}
@@ -114,7 +116,7 @@ class static_var<T[]> {
 		assert(builder_context::current_builder_context->static_var_tuples.size() > 0);
 		assert(builder_context::current_builder_context->static_var_tuples.back().ptr == (unsigned char *)val);
 		builder_context::current_builder_context->static_var_tuples.pop_back();
-		delete[] val;	
+		delete[] val;
 	}
 };
 } // namespace builder

--- a/samples/outputs.var_names/sample47
+++ b/samples/outputs.var_names/sample47
@@ -1,0 +1,86 @@
+FUNC_DECL
+  SCALAR_TYPE (VOID)
+  STMT_BLOCK
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (c_0)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (c_1)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (c_2)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (c_3)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (c_4)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (c_5)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (c_6)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (c_7)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (c_8)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (c_9)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (c_10)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (c_11)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (c_12)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (c_13)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (c_14)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (c_15)
+      INT_CONST (0)
+void my_bar (void) {
+  int c_0 = 0;
+  int c_1 = 0;
+  int c_2 = 0;
+  int c_3 = 0;
+  int c_4 = 0;
+  int c_5 = 0;
+  int c_6 = 0;
+  int c_7 = 0;
+  int c_8 = 0;
+  int c_9 = 0;
+  int c_10 = 0;
+  int c_11 = 0;
+  int c_12 = 0;
+  int c_13 = 0;
+  int c_14 = 0;
+  int c_15 = 0;
+}
+

--- a/samples/outputs/sample47
+++ b/samples/outputs/sample47
@@ -1,0 +1,86 @@
+FUNC_DECL
+  SCALAR_TYPE (VOID)
+  STMT_BLOCK
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (var0)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (var1)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (var2)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (var3)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (var4)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (var5)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (var6)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (var7)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (var8)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (var9)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (var10)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (var11)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (var12)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (var13)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (var14)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (var15)
+      INT_CONST (0)
+void my_bar (void) {
+  int var0 = 0;
+  int var1 = 0;
+  int var2 = 0;
+  int var3 = 0;
+  int var4 = 0;
+  int var5 = 0;
+  int var6 = 0;
+  int var7 = 0;
+  int var8 = 0;
+  int var9 = 0;
+  int var10 = 0;
+  int var11 = 0;
+  int var12 = 0;
+  int var13 = 0;
+  int var14 = 0;
+  int var15 = 0;
+}
+

--- a/samples/sample47.cpp
+++ b/samples/sample47.cpp
@@ -1,6 +1,6 @@
-#include "builder/static_var.h"
-#include "builder/dyn_var.h"
 #include "blocks/c_code_generator.h"
+#include "builder/dyn_var.h"
+#include "builder/static_var.h"
 
 using builder::dyn_var;
 using builder::static_var;
@@ -12,7 +12,7 @@ static void foo(void) {
 		for (states[1] = 0; states[1] < 2; states[1]++) {
 			for (states[2] = 0; states[2] < 2; states[2]++) {
 				for (states[3] = 0; states[3] < 2; states[3]++) {
-					dyn_var<int> c = 0;	
+					dyn_var<int> c = 0;
 				}
 			}
 		}

--- a/samples/sample47.cpp
+++ b/samples/sample47.cpp
@@ -1,0 +1,28 @@
+#include "builder/static_var.h"
+#include "builder/dyn_var.h"
+#include "blocks/c_code_generator.h"
+
+using builder::dyn_var;
+using builder::static_var;
+
+static void foo(void) {
+	static_var<int[]> states;
+	states.resize(4);
+	for (states[0] = 0; states[0] < 2; states[0]++) {
+		for (states[1] = 0; states[1] < 2; states[1]++) {
+			for (states[2] = 0; states[2] < 2; states[2]++) {
+				for (states[3] = 0; states[3] < 2; states[3]++) {
+					dyn_var<int> c = 0;	
+				}
+			}
+		}
+	}
+}
+int main(int argc, char *argv[]) {
+	builder::builder_context context;
+	auto ast = context.extract_function_ast(foo, "my_bar");
+	ast->dump(std::cout, 0);
+
+	block::c_code_generator::generate_code(ast, std::cout, 0);
+	return 0;
+}


### PR DESCRIPTION
Added a template specialization for static_var<T[]>. This would previously have to be handled by heap-allocating an array of static_vars which doesn't work well with the allocation and deletion orders. 
Sample 47 added to test it. 