### PR TITLE
Fixed a bug in sub expression cleanup

### DIFF
--- a/include/blocks/block.h
+++ b/include/blocks/block.h
@@ -110,6 +110,7 @@ public:
 			return false;
 		return true;
 	}
+
 };
 } // namespace block
 #endif

--- a/include/blocks/block.h
+++ b/include/blocks/block.h
@@ -110,7 +110,6 @@ public:
 			return false;
 		return true;
 	}
-
 };
 } // namespace block
 #endif

--- a/include/blocks/stmt.h
+++ b/include/blocks/stmt.h
@@ -29,6 +29,10 @@ public:
 
 	expr::Ptr expr1;
 
+	// member to keep track if this expr stmt 
+	// has been spuriously created and needs to be deleted
+	bool mark_for_deletion = false;
+
 	virtual bool is_same(block::Ptr other) override {
 		if (!isa<expr_stmt>(other))
 			return false;

--- a/include/blocks/stmt.h
+++ b/include/blocks/stmt.h
@@ -29,7 +29,7 @@ public:
 
 	expr::Ptr expr1;
 
-	// member to keep track if this expr stmt 
+	// member to keep track if this expr stmt
 	// has been spuriously created and needs to be deleted
 	bool mark_for_deletion = false;
 

--- a/include/blocks/sub_expr_cleanup.h
+++ b/include/blocks/sub_expr_cleanup.h
@@ -1,0 +1,12 @@
+#ifndef SUB_EXPR_CLEANUP_H
+#define SUB_EXPR_CLEANUP_H
+#include "blocks/block_visitor.h"
+#include "blocks/stmt.h"
+namespace block {
+class sub_expr_cleanup : public block_visitor {
+public:
+	using block_visitor::visit;
+	virtual void visit(stmt_block::Ptr);
+};
+} // namespace block
+#endif

--- a/samples/outputs.var_names/sample48
+++ b/samples/outputs.var_names/sample48
@@ -1,0 +1,26 @@
+FUNC_DECL
+  SCALAR_TYPE (VOID)
+  STMT_BLOCK
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (x_0)
+      NO_INITIALIZATION
+    WHILE_STMT
+      INT_CONST (1)
+      STMT_BLOCK
+        DECL_STMT
+          SCALAR_TYPE (INT)
+          VAR (var1)
+          INT_CONST (1)
+        DECL_STMT
+          SCALAR_TYPE (INT)
+          VAR (var2)
+          INT_CONST (2)
+void my_bar (void) {
+  int x_0;
+  while (1) {
+    int var1 = 1;
+    int var2 = 2;
+  }
+}
+

--- a/samples/outputs/sample48
+++ b/samples/outputs/sample48
@@ -1,0 +1,26 @@
+FUNC_DECL
+  SCALAR_TYPE (VOID)
+  STMT_BLOCK
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (var0)
+      NO_INITIALIZATION
+    WHILE_STMT
+      INT_CONST (1)
+      STMT_BLOCK
+        DECL_STMT
+          SCALAR_TYPE (INT)
+          VAR (var1)
+          INT_CONST (1)
+        DECL_STMT
+          SCALAR_TYPE (INT)
+          VAR (var2)
+          INT_CONST (2)
+void my_bar (void) {
+  int var0;
+  while (1) {
+    int var1 = 1;
+    int var2 = 2;
+  }
+}
+

--- a/samples/sample48.cpp
+++ b/samples/sample48.cpp
@@ -1,10 +1,10 @@
 #include "blocks/c_code_generator.h"
-#include "builder/dyn_var.h"
 #include "builder/array.h"
+#include "builder/dyn_var.h"
 #include "builder/static_var.h"
 
-using builder::dyn_var;
 using builder::dyn_arr;
+using builder::dyn_var;
 using builder::static_var;
 
 static void foo(void) {

--- a/samples/sample48.cpp
+++ b/samples/sample48.cpp
@@ -1,0 +1,22 @@
+#include "blocks/c_code_generator.h"
+#include "builder/dyn_var.h"
+#include "builder/array.h"
+#include "builder/static_var.h"
+
+using builder::dyn_var;
+using builder::dyn_arr;
+using builder::static_var;
+
+static void foo(void) {
+	dyn_var<int> x;
+	while (1)
+		dyn_arr<int, 2> z = {1, 2};
+}
+int main(int argc, char *argv[]) {
+	builder::builder_context context;
+	auto ast = context.extract_function_ast(foo, "my_bar");
+	ast->dump(std::cout, 0);
+
+	block::c_code_generator::generate_code(ast, std::cout, 0);
+	return 0;
+}

--- a/src/blocks/sub_expr_cleanup.cpp
+++ b/src/blocks/sub_expr_cleanup.cpp
@@ -4,10 +4,10 @@ namespace block {
 
 void sub_expr_cleanup::visit(stmt_block::Ptr sb) {
 	std::vector<stmt::Ptr> new_stmts;
-	for (auto stmt: sb->stmts) {
+	for (auto stmt : sb->stmts) {
 		if (!isa<expr_stmt>(stmt) || !to<expr_stmt>(stmt)->mark_for_deletion) {
-			new_stmts.push_back(stmt);	
-		} 	
+			new_stmts.push_back(stmt);
+		}
 	}
 	sb->stmts = new_stmts;
 	block_visitor::visit(sb);

--- a/src/blocks/sub_expr_cleanup.cpp
+++ b/src/blocks/sub_expr_cleanup.cpp
@@ -1,0 +1,16 @@
+#include "blocks/sub_expr_cleanup.h"
+
+namespace block {
+
+void sub_expr_cleanup::visit(stmt_block::Ptr sb) {
+	std::vector<stmt::Ptr> new_stmts;
+	for (auto stmt: sb->stmts) {
+		if (!isa<expr_stmt>(stmt) || !to<expr_stmt>(stmt)->mark_for_deletion) {
+			new_stmts.push_back(stmt);	
+		} 	
+	}
+	sb->stmts = new_stmts;
+	block_visitor::visit(sb);
+}
+
+} // namespace block

--- a/src/builder/builder_context.cpp
+++ b/src/builder/builder_context.cpp
@@ -1,6 +1,7 @@
 #include "builder/builder_context.h"
 #include "blocks/for_loop_finder.h"
 #include "blocks/if_switcher.h"
+#include "blocks/sub_expr_cleanup.h"
 #include "blocks/label_inserter.h"
 #include "blocks/loop_finder.h"
 #include "blocks/loop_roll.h"
@@ -97,18 +98,16 @@ void builder_context::remove_node_from_sequence(block::expr::Ptr e) {
 	} else {
 		// Could be committed already
 		// It is safe to update the parent block here, because the memoization doesn't care about indices
-		std::vector<block::stmt::Ptr> new_stmts;
+		// But don't actually delete the statement, because there could be gotos that are jumping here
+		// instead just mark it for deletion later
 		for (auto stmt : current_block_stmt->stmts) {
-			bool found = false;
 			if (block::isa<block::expr_stmt>(stmt)) {
 				auto expr_s = block::to<block::expr_stmt>(stmt);
-				if (expr_s->expr1 == e)
-					found = true;
+				if (expr_s->expr1 == e) {
+					expr_s->mark_for_deletion = true;
+				}
 			}
-			if (!found)
-				new_stmts.push_back(stmt);
 		}
-		current_block_stmt->stmts = new_stmts;
 	}
 }
 void builder_context::add_node_to_sequence(block::expr::Ptr e) {
@@ -283,6 +282,11 @@ block::stmt::Ptr builder_context::extract_ast_from_function_impl(void) {
 	block::label_inserter inserter;
 	inserter.offset_to_label = creator.offset_to_label;
 	ast->accept(&inserter);
+	
+	// At this point it is safe to remove statements that are 
+	// marked for deletion
+	block::sub_expr_cleanup cleaner;
+	ast->accept(&cleaner);
 
 	if (run_rce) {
 		block::eliminate_redundant_vars(ast);

--- a/src/builder/builder_context.cpp
+++ b/src/builder/builder_context.cpp
@@ -1,11 +1,11 @@
 #include "builder/builder_context.h"
 #include "blocks/for_loop_finder.h"
 #include "blocks/if_switcher.h"
-#include "blocks/sub_expr_cleanup.h"
 #include "blocks/label_inserter.h"
 #include "blocks/loop_finder.h"
 #include "blocks/loop_roll.h"
 #include "blocks/rce.h"
+#include "blocks/sub_expr_cleanup.h"
 #include "blocks/var_namer.h"
 #include "builder/builder.h"
 #include "builder/dyn_var.h"
@@ -282,8 +282,8 @@ block::stmt::Ptr builder_context::extract_ast_from_function_impl(void) {
 	block::label_inserter inserter;
 	inserter.offset_to_label = creator.offset_to_label;
 	ast->accept(&inserter);
-	
-	// At this point it is safe to remove statements that are 
+
+	// At this point it is safe to remove statements that are
 	// marked for deletion
 	block::sub_expr_cleanup cleaner;
 	ast->accept(&cleaner);


### PR DESCRIPTION
BuildIt had a bug because of the way we erase expression statements that are part of other expressions. If there is a goto targeting these statements, the goto cannot find its target anymore. 

The solution is not immediately delete an expression statement but mark it for deletion and clean it up after the labels have been inserted. 
Sample 48 has been added to test this. 

