### PR TITLE
Fixed bug related to missing copy constructor for static_var

### DIFF
--- a/include/builder/static_var.h
+++ b/include/builder/static_var.h
@@ -23,6 +23,21 @@ public:
 	static_assert(sizeof(T) < MAX_TRACKING_VAR_SIZE, "Currently builder::static_var supports variables of max size "
 							 "= " TOSTRING(MAX_TRACKING_VARIABLE_SIZE));
 	T val;
+
+	static_var(const static_var& other): static_var((T) other) {}
+	static_var& operator=(const static_var& other) {
+		*this = (T) other;
+		return *this;
+	}
+
+	template <typename OT>
+	static_var(const static_var<OT> &other): static_var((T)(OT) other) {}
+	template <typename OT>
+	static_var& operator=(const static_var<OT> &other) {
+		*this = (T) (OT) other;
+		return *this;
+	}
+
 	operator T &() {
 		return val;
 	}

--- a/samples/sample12.cpp
+++ b/samples/sample12.cpp
@@ -11,7 +11,8 @@ using builder::static_var;
 // A simple straight line code enclosed in a static loop. This should be
 // unrolled 10 times. There shouldn't be a loop in the AST
 static void foo(void) {
-	for (static_var<int> x = 0; x < 10; x++) {
+	static_var<long> y = 0;
+	for (static_var<int> x = y; x < 10; x++) {
 		dyn_var<int> a;
 		a = a + 1;
 	}


### PR DESCRIPTION
BuildIt had a bug where static_var didn't have a custom copy constructor. As a result when we have code like - 

```
static_var<int> x = y;
``` 
where y is also a static_var<int>, the default copy constructor is called. This is mostly OK for copying the internal stored value, but the static_var's tracking tuple is not recorded. As a result the call to the destructor fails trying to pop the tracking tuple off the stack. 

This change adds 2 new copy constructors for static_var<T> and static_var<OT>. Consequently 2 new operator= also need to be defined, since the copy constructor is user defined. 

sample12 has been changed to test this behavior.  