### PR TITLE
Added support for reference types and creating named variables with decl

### DIFF
--- a/include/blocks/block_replacer.h
+++ b/include/blocks/block_replacer.h
@@ -73,6 +73,7 @@ public:
 	virtual void visit(std::shared_ptr<type>) override;
 	virtual void visit(std::shared_ptr<scalar_type>) override;
 	virtual void visit(std::shared_ptr<pointer_type>) override;
+	virtual void visit(std::shared_ptr<reference_type>) override;
 	virtual void visit(std::shared_ptr<function_type>) override;
 	virtual void visit(std::shared_ptr<array_type>) override;
 	virtual void visit(std::shared_ptr<builder_var_type>) override;

--- a/include/blocks/block_visitor.h
+++ b/include/blocks/block_visitor.h
@@ -56,6 +56,7 @@ class var;
 class type;
 class scalar_type;
 class pointer_type;
+class reference_type;
 class function_type;
 class array_type;
 class builder_var_type;
@@ -119,6 +120,7 @@ public:
 	virtual void visit(std::shared_ptr<type>);
 	virtual void visit(std::shared_ptr<scalar_type>);
 	virtual void visit(std::shared_ptr<pointer_type>);
+	virtual void visit(std::shared_ptr<reference_type>);
 	virtual void visit(std::shared_ptr<function_type>);
 	virtual void visit(std::shared_ptr<array_type>);
 	virtual void visit(std::shared_ptr<builder_var_type>);

--- a/include/blocks/c_code_generator.h
+++ b/include/blocks/c_code_generator.h
@@ -57,6 +57,7 @@ public:
 	virtual void visit(var::Ptr);
 	virtual void visit(scalar_type::Ptr);
 	virtual void visit(pointer_type::Ptr);
+	virtual void visit(reference_type::Ptr);
 	virtual void visit(array_type::Ptr);
 	virtual void visit(builder_var_type::Ptr);
 	virtual void visit(named_type::Ptr);

--- a/include/blocks/var.h
+++ b/include/blocks/var.h
@@ -47,6 +47,17 @@ public:
 	}
 	virtual void dump(std::ostream &, int) override;
 };
+
+class reference_type : public type {
+public:
+	typedef std::shared_ptr<reference_type> Ptr;
+	type::Ptr referenced_type;
+	virtual void accept(block_visitor *a) override {
+		a->visit(self<reference_type>());
+	}
+	virtual void dump(std::ostream &, int) override;
+};
+
 class function_type : public type {
 public:
 	typedef std::shared_ptr<function_type> Ptr;

--- a/include/builder/block_type_extractor.h
+++ b/include/builder/block_type_extractor.h
@@ -153,6 +153,16 @@ public:
 		return type;
 	}
 };
+// Type specialization for reference type
+template <typename T>
+class type_extractor<T &> {
+public:
+	static block::type::Ptr extract_type(void) {
+		block::reference_type::Ptr type = std::make_shared<block::reference_type>();
+		type->referenced_type = type_extractor<T>::extract_type();
+		return type;
+	}
+};
 
 template <>
 class type_extractor<void> {

--- a/include/builder/dyn_var.h
+++ b/include/builder/dyn_var.h
@@ -86,7 +86,8 @@ struct as_global {
 // With name is just like as_global but can be used locally
 struct with_name {
 	std::string name;
-	with_name(const std::string &n) : name(n) {}
+	bool with_decl;
+	with_name(const std::string &n, bool wd = false) : name(n), with_decl(wd) {}
 };
 
 template <typename T>
@@ -220,8 +221,9 @@ public:
 	}
 	dyn_var_impl(const with_name &v) {
 		// with_name constructors don't usually get declarations
-		create_dyn_var(true);
+		create_dyn_var(!v.with_decl);
 		block_var->var_name = v.name;
+		block_var->preferred_name = "";
 		var_name = v.name;
 	}
 	dyn_var_impl(const dyn_var_sentinel_type &a, std::string name = "") {

--- a/include/builder/static_var.h
+++ b/include/builder/static_var.h
@@ -24,17 +24,17 @@ public:
 							 "= " TOSTRING(MAX_TRACKING_VARIABLE_SIZE));
 	T val;
 
-	static_var(const static_var& other): static_var((T) other) {}
-	static_var& operator=(const static_var& other) {
-		*this = (T) other;
+	static_var(const static_var &other) : static_var((T)other) {}
+	static_var &operator=(const static_var &other) {
+		*this = (T)other;
 		return *this;
 	}
 
 	template <typename OT>
-	static_var(const static_var<OT> &other): static_var((T)(OT) other) {}
+	static_var(const static_var<OT> &other) : static_var((T)(OT)other) {}
 	template <typename OT>
-	static_var& operator=(const static_var<OT> &other) {
-		*this = (T) (OT) other;
+	static_var &operator=(const static_var<OT> &other) {
+		*this = (T)(OT)other;
 		return *this;
 	}
 

--- a/samples/outputs.var_names/sample10
+++ b/samples/outputs.var_names/sample10
@@ -14,7 +14,25 @@ STMT_BLOCK
         VAR_EXPR
           VAR (a_0)
         INT_CONST (6)
+  DECL_STMT
+    REFERENCE_TYPE
+      SCALAR_TYPE (INT)
+    VAR (b_1)
+    SQ_BKT_EXPR
+      VAR_EXPR
+        VAR (a_0)
+      INT_CONST (0)
+  EXPR_STMT
+    ASSIGN_EXPR
+      VAR_EXPR
+        VAR (b_1)
+      PLUS_EXPR
+        VAR_EXPR
+          VAR (b_1)
+        INT_CONST (1)
 {
   int* a_0;
   a_0[5] = a_0[6];
+  int& b_1 = a_0[0];
+  b_1 = b_1 + 1;
 }

--- a/samples/outputs.var_names/sample49
+++ b/samples/outputs.var_names/sample49
@@ -1,0 +1,23 @@
+FUNC_DECL
+  SCALAR_TYPE (VOID)
+  STMT_BLOCK
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (my_var)
+      NO_INITIALIZATION
+    EXPR_STMT
+      ASSIGN_EXPR
+        VAR_EXPR
+          VAR (my_var)
+        INT_CONST (1)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (y_0)
+      VAR_EXPR
+        VAR (my_var)
+void foo (void) {
+  int my_var;
+  my_var = 1;
+  int y_0 = my_var;
+}
+

--- a/samples/outputs/sample10
+++ b/samples/outputs/sample10
@@ -14,7 +14,25 @@ STMT_BLOCK
         VAR_EXPR
           VAR (var0)
         INT_CONST (6)
+  DECL_STMT
+    REFERENCE_TYPE
+      SCALAR_TYPE (INT)
+    VAR (var1)
+    SQ_BKT_EXPR
+      VAR_EXPR
+        VAR (var0)
+      INT_CONST (0)
+  EXPR_STMT
+    ASSIGN_EXPR
+      VAR_EXPR
+        VAR (var1)
+      PLUS_EXPR
+        VAR_EXPR
+          VAR (var1)
+        INT_CONST (1)
 {
   int* var0;
   var0[5] = var0[6];
+  int& var1 = var0[0];
+  var1 = var1 + 1;
 }

--- a/samples/outputs/sample49
+++ b/samples/outputs/sample49
@@ -1,0 +1,23 @@
+FUNC_DECL
+  SCALAR_TYPE (VOID)
+  STMT_BLOCK
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (my_var)
+      NO_INITIALIZATION
+    EXPR_STMT
+      ASSIGN_EXPR
+        VAR_EXPR
+          VAR (my_var)
+        INT_CONST (1)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (var0)
+      VAR_EXPR
+        VAR (my_var)
+void foo (void) {
+  int my_var;
+  my_var = 1;
+  int var0 = my_var;
+}
+

--- a/samples/sample49.cpp
+++ b/samples/sample49.cpp
@@ -1,21 +1,20 @@
 #include "blocks/c_code_generator.h"
-#include "builder/builder.h"
-#include "builder/builder_context.h"
 #include "builder/dyn_var.h"
-#include <iostream>
+
 using builder::dyn_var;
 
-// Pointer variables
 static void foo(void) {
-	dyn_var<int *> a;
-	a[5] = a[6];
-	dyn_var<int &> b = a[0];
-	b = b + 1;
+	std::string name = "my_var";
+	dyn_var<int> v = builder::with_name(name, true);
+	v = 1;
+	dyn_var<int> v1 = builder::with_name(name);
+	dyn_var<int> y = v1;
 }
 int main(int argc, char *argv[]) {
 	builder::builder_context context;
-	auto ast = context.extract_ast_from_function(foo);
+	auto ast = context.extract_function_ast(foo, "foo");
 	ast->dump(std::cout, 0);
+
 	block::c_code_generator::generate_code(ast, std::cout, 0);
 	return 0;
 }

--- a/src/blocks/block_replacer.cpp
+++ b/src/blocks/block_replacer.cpp
@@ -199,6 +199,10 @@ void block_replacer::visit(pointer_type::Ptr a) {
 	a->pointee_type = rewrite<type>(a->pointee_type);
 	node = a;
 }
+void block_replacer::visit(reference_type::Ptr a) {
+	a->referenced_type = rewrite<type>(a->referenced_type);
+	node = a;
+}
 void block_replacer::visit(function_type::Ptr a) {
 	a->return_type = rewrite<type>(a->return_type);
 	for (unsigned int i = 0; i < a->arg_types.size(); i++) {

--- a/src/blocks/block_visitor.cpp
+++ b/src/blocks/block_visitor.cpp
@@ -160,6 +160,9 @@ void block_visitor::visit(scalar_type::Ptr a) {}
 void block_visitor::visit(pointer_type::Ptr a) {
 	a->pointee_type->accept(this);
 }
+void block_visitor::visit(reference_type::Ptr a) {
+	a->referenced_type->accept(this);
+}
 void block_visitor::visit(function_type::Ptr a) {
 	a->return_type->accept(this);
 	for (unsigned int i = 0; i < a->arg_types.size(); i++)

--- a/src/blocks/c_code_generator.cpp
+++ b/src/blocks/c_code_generator.cpp
@@ -204,6 +204,13 @@ void c_code_generator::visit(pointer_type::Ptr type) {
 	type->pointee_type->accept(this);
 	oss << "*";
 }
+void c_code_generator::visit(reference_type::Ptr type) {
+	if (!isa<scalar_type>(type->referenced_type) && !isa<pointer_type>(type->referenced_type) &&
+	    !isa<named_type>(type->referenced_type))
+		assert(false && "Printing pointers of complex type is not supported yet");
+	type->referenced_type->accept(this);
+	oss << "&";
+}
 void c_code_generator::visit(array_type::Ptr type) {
 	if (!isa<scalar_type>(type->element_type) && !isa<pointer_type>(type->element_type) &&
 	    !isa<named_type>(type->element_type))

--- a/src/blocks/var.cpp
+++ b/src/blocks/var.cpp
@@ -48,6 +48,11 @@ void pointer_type::dump(std::ostream &oss, int indent) {
 	oss << "POINTER_TYPE" << std::endl;
 	pointee_type->dump(oss, indent + 1);
 }
+void reference_type::dump(std::ostream &oss, int indent) {
+	printer::indent(oss, indent);
+	oss << "REFERENCE_TYPE" << std::endl;
+	referenced_type->dump(oss, indent + 1);
+}
 void function_type::dump(std::ostream &oss, int indent) {
 	printer::indent(oss, indent);
 	oss << "FUNCITON_TYPE" << std::endl;

--- a/src/blocks/var_namer.cpp
+++ b/src/blocks/var_namer.cpp
@@ -13,6 +13,11 @@ void var_namer::visit(decl_stmt::Ptr stmt) {
 		stmt->decl_var = collected_decls[so];
 		return;
 	}
+
+	// If a variable already has a name, created with with_name(_, true), skip naming it
+	if (stmt->decl_var->var_name != "")
+		return;
+
 	// We have found a new variable decl, first assign it a name
 	if (stmt->decl_var->preferred_name != "") {
 		stmt->decl_var->var_name = stmt->decl_var->preferred_name + "_" + std::to_string(var_counter);


### PR DESCRIPTION
This change adds two features - 
1. Support for reference types - dyn_var<T&>. Very similar in implementation to pointer type. builder::block_type_extractor specialization has been added to create these types. Sample 10 updated to test this
2. Support for creating named variables with declaration. The builder::with_name helper now has an extra boolean parameter (defaulted to false) to also emit a declaration. This allows creating local variables with exact names. 

Both these features are required by the FPGA util library and backen. 