### PR TITLE
Fixed the bug with labels not being duplicated across branches

### DIFF
--- a/include/blocks/label_inserter.h
+++ b/include/blocks/label_inserter.h
@@ -23,8 +23,19 @@ public:
 class label_inserter : public block_visitor {
 public:
 	using block_visitor::visit;
+
+	// The main table to hold static tag to label mapping
+	// this table holds the jump target that is in the parent of the
+	// jump statement
 	std::unordered_map<std::string, label::Ptr> offset_to_label;
+	// A backup table which has atleast one label that we can jump to
+	// Only used when feature_unstructured is used
+	std::unordered_map<std::string, label::Ptr> backup_offset_to_label;
+
+	bool feature_unstructured;
+
 	virtual void visit(goto_stmt::Ptr);
+	virtual void visit(label_stmt::Ptr);
 };
 } // namespace block
 #endif

--- a/samples/outputs.var_names/sample50
+++ b/samples/outputs.var_names/sample50
@@ -1,0 +1,56 @@
+FUNC_DECL
+  SCALAR_TYPE (VOID)
+  STMT_BLOCK
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (k_0)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (t_1)
+      INT_CONST (0)
+    WHILE_STMT
+      INT_CONST (1)
+      STMT_BLOCK
+        IF_STMT
+          NE_EXPR
+            VAR_EXPR
+              VAR (k_0)
+            INT_CONST (1)
+          STMT_BLOCK
+            IF_STMT
+              EQUALS_EXPR
+                VAR_EXPR
+                  VAR (k_0)
+                INT_CONST (2)
+              STMT_BLOCK
+                WHILE_STMT
+                  NE_EXPR
+                    VAR_EXPR
+                      VAR (k_0)
+                    INT_CONST (3)
+                  STMT_BLOCK
+              STMT_BLOCK
+          STMT_BLOCK
+            WHILE_STMT
+              NE_EXPR
+                VAR_EXPR
+                  VAR (k_0)
+                INT_CONST (3)
+              STMT_BLOCK
+void bar (void) {
+  int k_0 = 0;
+  int t_1 = 0;
+  while (1) {
+    if (k_0 != 1) {
+      if (k_0 == 2) {
+        while (k_0 != 3) {
+        }
+      } 
+    } else {
+      while (k_0 != 3) {
+      }
+    }
+  }
+}
+

--- a/samples/outputs/sample50
+++ b/samples/outputs/sample50
@@ -1,0 +1,56 @@
+FUNC_DECL
+  SCALAR_TYPE (VOID)
+  STMT_BLOCK
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (var0)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (var1)
+      INT_CONST (0)
+    WHILE_STMT
+      INT_CONST (1)
+      STMT_BLOCK
+        IF_STMT
+          NE_EXPR
+            VAR_EXPR
+              VAR (var0)
+            INT_CONST (1)
+          STMT_BLOCK
+            IF_STMT
+              EQUALS_EXPR
+                VAR_EXPR
+                  VAR (var0)
+                INT_CONST (2)
+              STMT_BLOCK
+                WHILE_STMT
+                  NE_EXPR
+                    VAR_EXPR
+                      VAR (var0)
+                    INT_CONST (3)
+                  STMT_BLOCK
+              STMT_BLOCK
+          STMT_BLOCK
+            WHILE_STMT
+              NE_EXPR
+                VAR_EXPR
+                  VAR (var0)
+                INT_CONST (3)
+              STMT_BLOCK
+void bar (void) {
+  int var0 = 0;
+  int var1 = 0;
+  while (1) {
+    if (var0 != 1) {
+      if (var0 == 2) {
+        while (var0 != 3) {
+        }
+      } 
+    } else {
+      while (var0 != 3) {
+      }
+    }
+  }
+}
+

--- a/samples/sample50.cpp
+++ b/samples/sample50.cpp
@@ -1,0 +1,30 @@
+#include "blocks/c_code_generator.h"
+#include "builder/builder.h"
+#include "builder/builder_context.h"
+#include "builder/dyn_var.h"
+#include "builder/static_var.h"
+#include <iostream>
+using builder::dyn_var;
+using builder::static_var;
+
+static void bar(void) {
+	dyn_var<int> k = 0;
+	dyn_var<int> t = 0;
+	while (1) {
+		while (k != 1) {
+
+			if (k == 2)
+				break;
+		}
+		while (k != 3) {
+		}
+	}
+}
+
+int main(int argc, char *argv[]) {
+	builder::builder_context context;
+	auto ast = context.extract_function_ast(bar, "bar");
+	ast->dump(std::cout, 0);
+	block::c_code_generator::generate_code(ast, std::cout, 0);
+	return 0;
+}

--- a/src/builder/builder_context.cpp
+++ b/src/builder/builder_context.cpp
@@ -144,6 +144,7 @@ static void trim_ast_at_offset(block::stmt::Ptr ast, tracer::tag offset) {
 
 static std::pair<std::vector<block::stmt::Ptr>, std::vector<block::stmt::Ptr>>
 trim_common_from_back(block::stmt::Ptr ast1, block::stmt::Ptr ast2) {
+
 	std::vector<block::stmt::Ptr> trimmed_stmts;
 	std::vector<block::stmt::Ptr> &ast1_stmts = block::to<block::stmt_block>(ast1)->stmts;
 	std::vector<block::stmt::Ptr> &ast2_stmts = block::to<block::stmt_block>(ast2)->stmts;
@@ -280,7 +281,8 @@ block::stmt::Ptr builder_context::extract_ast_from_function_impl(void) {
 	ast->accept(&creator);
 
 	block::label_inserter inserter;
-	inserter.offset_to_label = creator.offset_to_label;
+	inserter.backup_offset_to_label = creator.offset_to_label;
+	inserter.feature_unstructured = feature_unstructured;
 	ast->accept(&inserter);
 
 	// At this point it is safe to remove statements that are


### PR DESCRIPTION
Fixes #53 

The bug in the referenced issue was because of jumps and jump targets being duplicated across branches due to "failure to merge". This causes the jump to target a label that is in a different branch messing up the loop_finder invariant. 

We fixed this by inserting labels at all possible jump targets for a particular static label. We then maintain the current label from the stmt block and update it when we visit a new one. This way a goto stmt always sees a structured label. 

Sample 50 has been added to test the same. 