### PR TITLE
Allow flattening ifs when a branch ends in return

### DIFF
--- a/.github/workflows/ci-all-samples.yml
+++ b/.github/workflows/ci-all-samples.yml
@@ -9,10 +9,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - run: make -C ${{ github.workspace }} run
+      - run: make -C ${{ github.workspace }} -j$(nproc) run
       - name: Install libunwind-dev
         run: sudo apt-get install libunwind-dev libdwarf-dev=20200114-1 libdwarf1=20200114-1
-      - run: make -C ${{ github.workspace }} RECOVER_VAR_NAMES=1 run
+      - run: make -C ${{ github.workspace }} RECOVER_VAR_NAMES=1 -j$(nproc) run
       - run: echo "Tests completed"
   CI-Actions-MacOs:
     runs-on: 	macos-latest
@@ -20,5 +20,5 @@ jobs:
       - run: echo "Starting tests"
       - name: Checking out repository
         uses: actions/checkout@v2
-      - run: make -C ${{ github.workspace }} run
+      - run: make -C ${{ github.workspace }} -j$(nproc) run
       - run: echo "Tests completed"

--- a/include/builder/lib/utils.h
+++ b/include/builder/lib/utils.h
@@ -7,7 +7,7 @@ template <typename T>
 static_var<T> up_cast_range(dyn_var<T> &v, T range) {
 	static_var<T> s;
 	for (s = 0; s < range - 1; s++) {
-		if (s == v) {
+		if (v == s) {
 			return s;
 		}
 	}

--- a/samples/outputs.var_names/sample40
+++ b/samples/outputs.var_names/sample40
@@ -26,35 +26,28 @@ int match_re (char* arg1) {
               if (to_match_2 < str_len_1) {
                 var3 = 0;
                 return var3;
-              } else {
-                return 1;
-              }
-            } else {
-              var3 = 0;
-              return var3;
-            }
-          } else {
-            var5 = 0;
-            return var5;
-          }
-        } else {
-          if (arg1[to_match_2] == 100) {
-            goto label2;
+              } 
+              return 1;
+            } 
+            var3 = 0;
+            return var3;
           } 
-          var3 = 0;
-          return var3;
-        }
-      } else {
-        var5 = 0;
-        return var5;
-      }
-    } else {
-      var3 = 0;
-      return var3;
-    }
-  } else {
-    var5 = 0;
-    return var5;
-  }
+          var5 = 0;
+          return var5;
+        } 
+        if (arg1[to_match_2] == 100) {
+          goto label2;
+        } 
+        var3 = 0;
+        return var3;
+      } 
+      var5 = 0;
+      return var5;
+    } 
+    var3 = 0;
+    return var3;
+  } 
+  var5 = 0;
+  return var5;
 }
 

--- a/samples/outputs.var_names/sample52
+++ b/samples/outputs.var_names/sample52
@@ -1,0 +1,49 @@
+int isEven (int arg0) {
+  if (arg0 == 0) {
+    return 1;
+  } 
+  if (arg0 == 1) {
+    return 0;
+  } 
+  if (arg0 == 2) {
+    return 1;
+  } 
+  if (arg0 == 3) {
+    return 0;
+  } 
+  if (arg0 == 4) {
+    return 1;
+  } 
+  if (arg0 == 5) {
+    return 0;
+  } 
+  if (arg0 == 6) {
+    return 1;
+  } 
+  if (arg0 == 7) {
+    return 0;
+  } 
+  if (arg0 == 8) {
+    return 1;
+  } 
+  if (arg0 == 9) {
+    return 0;
+  } 
+  if (arg0 == 10) {
+    return 1;
+  } 
+  if (arg0 == 11) {
+    return 0;
+  } 
+  if (arg0 == 12) {
+    return 1;
+  } 
+  if (arg0 == 13) {
+    return 0;
+  } 
+  if (arg0 == 14) {
+    return 1;
+  } 
+  return 0;
+}
+

--- a/samples/outputs/sample
+++ b/samples/outputs/sample
@@ -1,0 +1,49 @@
+int isEven (int arg0) {
+  if (arg0 == 0) {
+    return 1;
+  } 
+  if (arg0 == 1) {
+    return 0;
+  } 
+  if (arg0 == 2) {
+    return 1;
+  } 
+  if (arg0 == 3) {
+    return 0;
+  } 
+  if (arg0 == 4) {
+    return 1;
+  } 
+  if (arg0 == 5) {
+    return 0;
+  } 
+  if (arg0 == 6) {
+    return 1;
+  } 
+  if (arg0 == 7) {
+    return 0;
+  } 
+  if (arg0 == 8) {
+    return 1;
+  } 
+  if (arg0 == 9) {
+    return 0;
+  } 
+  if (arg0 == 10) {
+    return 1;
+  } 
+  if (arg0 == 11) {
+    return 0;
+  } 
+  if (arg0 == 12) {
+    return 1;
+  } 
+  if (arg0 == 13) {
+    return 0;
+  } 
+  if (arg0 == 14) {
+    return 1;
+  } 
+  return 0;
+}
+

--- a/samples/outputs/sample40
+++ b/samples/outputs/sample40
@@ -26,35 +26,28 @@ int match_re (char* arg1) {
               if (var2 < var1) {
                 var3 = 0;
                 return var3;
-              } else {
-                return 1;
-              }
-            } else {
-              var3 = 0;
-              return var3;
-            }
-          } else {
-            var5 = 0;
-            return var5;
-          }
-        } else {
-          if (arg1[var2] == 100) {
-            goto label2;
+              } 
+              return 1;
+            } 
+            var3 = 0;
+            return var3;
           } 
-          var3 = 0;
-          return var3;
-        }
-      } else {
-        var5 = 0;
-        return var5;
-      }
-    } else {
-      var3 = 0;
-      return var3;
-    }
-  } else {
-    var5 = 0;
-    return var5;
-  }
+          var5 = 0;
+          return var5;
+        } 
+        if (arg1[var2] == 100) {
+          goto label2;
+        } 
+        var3 = 0;
+        return var3;
+      } 
+      var5 = 0;
+      return var5;
+    } 
+    var3 = 0;
+    return var3;
+  } 
+  var5 = 0;
+  return var5;
 }
 

--- a/samples/outputs/sample52
+++ b/samples/outputs/sample52
@@ -1,0 +1,49 @@
+int isEven (int arg0) {
+  if (arg0 == 0) {
+    return 1;
+  } 
+  if (arg0 == 1) {
+    return 0;
+  } 
+  if (arg0 == 2) {
+    return 1;
+  } 
+  if (arg0 == 3) {
+    return 0;
+  } 
+  if (arg0 == 4) {
+    return 1;
+  } 
+  if (arg0 == 5) {
+    return 0;
+  } 
+  if (arg0 == 6) {
+    return 1;
+  } 
+  if (arg0 == 7) {
+    return 0;
+  } 
+  if (arg0 == 8) {
+    return 1;
+  } 
+  if (arg0 == 9) {
+    return 0;
+  } 
+  if (arg0 == 10) {
+    return 1;
+  } 
+  if (arg0 == 11) {
+    return 0;
+  } 
+  if (arg0 == 12) {
+    return 1;
+  } 
+  if (arg0 == 13) {
+    return 0;
+  } 
+  if (arg0 == 14) {
+    return 1;
+  } 
+  return 0;
+}
+

--- a/samples/sample52.cpp
+++ b/samples/sample52.cpp
@@ -1,0 +1,22 @@
+// Include the headers
+#include "blocks/c_code_generator.h"
+#include "builder/dyn_var.h"
+#include "builder/lib/utils.h"
+#include "builder/static_var.h"
+#include <iostream>
+
+// Include the BuildIt types
+using builder::dyn_var;
+using builder::static_var;
+
+static dyn_var<int> isEven(dyn_var<int> x) {
+	static_var<int> xs = builder::up_cast_range(x, 16);
+	return (xs % 2) == 0;
+}
+
+int main(int argc, char *argv[]) {
+	builder::builder_context context;
+	context.run_rce = true;
+	block::c_code_generator::generate_code(context.extract_function_ast(isEven, "isEven"), std::cout, 0);
+	return 0;
+}

--- a/src/builder/builder_context.cpp
+++ b/src/builder/builder_context.cpp
@@ -243,14 +243,17 @@ trim_common_from_back(block::stmt::Ptr ast1, block::stmt::Ptr ast2) {
 	// the common part This has to be checked only in the end because gotos
 	// can appear on both the sides and should be trimmed of before
 
+	// Also allow this optimization if one of the branch ends in return
 	if (ast1_stmts.size() != 0 && ast2_stmts.size() != 0) {
-		if (block::isa<block::goto_stmt>(ast1_stmts.back())) {
+		if (block::isa<block::goto_stmt>(ast1_stmts.back()) ||
+		    block::isa<block::return_stmt>(ast1_stmts.back())) {
 			while (ast2_stmts.size() > 0) {
 				block::stmt::Ptr trimmed_stmt = ast2_stmts.back();
 				ast2_stmts.pop_back();
 				trimmed_stmts.push_back(trimmed_stmt);
 			}
-		} else if (block::isa<block::goto_stmt>(ast2_stmts.back())) {
+		} else if (block::isa<block::goto_stmt>(ast2_stmts.back()) ||
+			   block::isa<block::return_stmt>(ast2_stmts.back())) {
 			while (ast1_stmts.size() > 0) {
 				block::stmt::Ptr trimmed_stmt = ast1_stmts.back();
 				ast1_stmts.pop_back();

--- a/src/builder/builder_dynamic.cpp
+++ b/src/builder/builder_dynamic.cpp
@@ -33,8 +33,8 @@ void *compile_and_return_ptr(builder_context &context, std::string source_name, 
 		compiler_name += " -std=c++11 -fPIC ";
 	}
 
-	std::string compile_command = compiler_name + " -shared -O3 " + source_name + " -o " + compiled_name + " "
-		+ context.dynamic_compiler_flags;
+	std::string compile_command = compiler_name + " -shared -O3 " + source_name + " -o " + compiled_name + " " +
+				      context.dynamic_compiler_flags;
 
 	int err = system(compile_command.c_str());
 	if (err != 0) {


### PR DESCRIPTION
Allow converting ifs like 

```
if (foo) {
    bar();
    return x;
else {
    baz();
}
```

into 

```
if (foo) {
    bar();
    return x;
}
baz();

```

Sample 52 tests this. 

Minor change: Changed order or operands in the comparison in up_cast_range. 