### PR TITLE
Added support for defer init for dyn_var

### DIFF
--- a/include/builder/dyn_var.h
+++ b/include/builder/dyn_var.h
@@ -90,6 +90,13 @@ struct with_name {
 	with_name(const std::string &n, bool wd = false) : name(n), with_decl(wd) {}
 };
 
+// constructor helper to defer the initialization of dyn_var
+// This allows declaring dyn_var outside the context, but initialize
+// them later
+struct defer_init {
+	// No members
+};
+
 template <typename T>
 class dyn_var_impl : public var {
 public:
@@ -225,6 +232,19 @@ public:
 		block_var->var_name = v.name;
 		block_var->preferred_name = "";
 		var_name = v.name;
+	}
+
+	dyn_var_impl(const defer_init&) {
+		// Do nothing here
+	}
+	// The function to actually initialize a dyn_var, if it 
+	// has been deferred. It is OKAY to call this even if defer_init
+	// is not used, but is not adviced. This can definitely be called multiple 
+	// times and will produce the same dyn_var based on the static tag at the
+	// time of this call
+	// Currently we don't support init val, but can be added if needed
+	void deferred_init(void) {
+		create_dyn_var(false);
 	}
 	dyn_var_impl(const dyn_var_sentinel_type &a, std::string name = "") {
 		create_dyn_var(true);

--- a/samples/outputs.var_names/sample53
+++ b/samples/outputs.var_names/sample53
@@ -1,0 +1,10 @@
+void foo (void) {
+  int obj_0;
+  int x_1 = 0;
+  if (x_1) {
+    obj_0 = 1;
+  } else {
+    obj_0 = 2;
+  }
+}
+

--- a/samples/outputs/sample53
+++ b/samples/outputs/sample53
@@ -1,0 +1,10 @@
+void foo (void) {
+  int var0;
+  int var1 = 0;
+  if (var1) {
+    var0 = 1;
+  } else {
+    var0 = 2;
+  }
+}
+

--- a/samples/sample53.cpp
+++ b/samples/sample53.cpp
@@ -1,0 +1,36 @@
+// Include the headers
+#include "blocks/c_code_generator.h"
+#include "builder/dyn_var.h"
+#include "builder/lib/utils.h"
+#include "builder/static_var.h"
+#include <iostream>
+
+// Include the BuildIt types
+using builder::dyn_var;
+using builder::static_var;
+
+
+struct external_object_t {
+	dyn_var<int> member = builder::defer_init();
+};
+
+static void foo(external_object_t &obj) {	
+	// Init not
+	obj.member.deferred_init();
+	
+	dyn_var<int> x = 0;
+	if (x) {
+		obj.member = 1;	
+	} else {
+		obj.member = 2;
+	}	
+}
+
+int main(int argc, char *argv[]) {
+
+	external_object_t obj;
+
+	builder::builder_context context;
+	block::c_code_generator::generate_code(context.extract_function_ast(foo, "foo", obj), std::cout, 0);
+	return 0;
+}


### PR DESCRIPTION
Usually when dyn_var are instantiated, they are immediately initialized. This means they can be declared only inside builder contexts (or should use as_global or with_name). 

This is restrictive when the user wants to create objects outside the context that have dyn_var members. Currently this requires the user to push the creation of the entire object inside the context. It creates issues with expensive computations being run multiple times. To get around this, we add a new constructor helper `builder::defer_init` and a member function `deferred_init`. 

The constructor helper allows declaring dyn_var(s) without actually doing anything. The member function `deferred_init`, then does the job of the constructor and should be called inside the context. 

Added sample53 to demonstrate/test this. 