### PR TITLE
Fixed bug with dynamic variables escaping static scopes getting diffe…

### DIFF
--- a/include/blocks/var_namer.h
+++ b/include/blocks/var_namer.h
@@ -8,6 +8,14 @@
 
 namespace block {
 
+class var_gather_escapes : public block_visitor {
+public:
+	using block_visitor::visit;
+	std::vector<std::string> &escaping_tags;
+	var_gather_escapes(std::vector<std::string> &e) : escaping_tags(e) {}
+	virtual void visit(decl_stmt::Ptr) override;
+};
+
 class var_namer : public block_visitor {
 public:
 	using block_visitor::visit;
@@ -15,6 +23,9 @@ public:
 	std::map<std::string, var::Ptr> collected_decls;
 	std::map<std::string, decl_stmt::Ptr> decls_to_hoist;
 	std::vector<std::string> decl_tags_to_hoist;
+
+	std::vector<std::string> escaping_tags;
+
 	virtual void visit(decl_stmt::Ptr) override;
 
 	static void name_vars(block::Ptr ast);
@@ -24,7 +35,9 @@ class var_replacer : public block_visitor {
 public:
 	using block_visitor::visit;
 	std::map<std::string, var::Ptr> &collected_decls;
-	var_replacer(std::map<std::string, var::Ptr> &d) : collected_decls(d) {}
+	std::vector<std::string> &escaping_tags;
+	var_replacer(std::map<std::string, var::Ptr> &d, std::vector<std::string> &e)
+	    : collected_decls(d), escaping_tags(e) {}
 
 	virtual void visit(var_expr::Ptr) override;
 };
@@ -33,7 +46,9 @@ class var_hoister : public block_replacer {
 public:
 	using block_replacer::visit;
 	std::map<std::string, decl_stmt::Ptr> &decls_to_hoist;
-	var_hoister(std::map<std::string, decl_stmt::Ptr> &d) : decls_to_hoist(d) {}
+	std::vector<std::string> &escaping_tags;
+	var_hoister(std::map<std::string, decl_stmt::Ptr> &d, std::vector<std::string> &e)
+	    : decls_to_hoist(d), escaping_tags(e) {}
 	virtual void visit(decl_stmt::Ptr) override;
 };
 

--- a/include/builder/array.h
+++ b/include/builder/array.h
@@ -19,6 +19,15 @@ public:
 			for (static_var<size_t> i = 0; i < actual_size; i++) {
 				new (m_arr + i) dyn_var<T>();
 			}
+			// static tags for array nodes need to be adjusted
+			// so they are treated different from each other despite
+			// being declared at the same location.
+			// dyn_arr are special case of vars that escape their static scope but still
+			// shouldn't be treated together
+			// We do this by adding additional metadata on all of them
+			for (static_var<size_t> i = 0; i < actual_size; i++) {
+				m_arr[i].block_var->template setMetadata<int>("allow_escape_scope", 1);
+			}
 		}
 	}
 	dyn_arr(const std::initializer_list<builder> &init) {
@@ -34,6 +43,9 @@ public:
 			else
 				new (m_arr + i) dyn_var<T>();
 		}
+		for (static_var<size_t> i = 0; i < actual_size; i++) {
+			m_arr[i].block_var->template setMetadata<int>("allow_escape_scope", 1);
+		}
 	}
 	void set_size(size_t new_size) {
 		assert(size == 0 && "set_size should be only called for dyn_arr without size");
@@ -42,6 +54,9 @@ public:
 		m_arr = (dyn_var<T> *)new char[sizeof(dyn_var<T>) * actual_size];
 		for (static_var<size_t> i = 0; i < actual_size; i++) {
 			new (m_arr + i) dyn_var<T>();
+		}
+		for (static_var<size_t> i = 0; i < actual_size; i++) {
+			m_arr[i].block_var->template setMetadata<int>("allow_escape_scope", 1);
 		}
 	}
 
@@ -58,6 +73,9 @@ public:
 				new (m_arr + i) dyn_var<T>(other[i]);
 			else
 				new (m_arr + i) dyn_var<T>();
+		}
+		for (static_var<size_t> i = 0; i < actual_size; i++) {
+			m_arr[i].block_var->template setMetadata<int>("allow_escape_scope", 1);
 		}
 	}
 

--- a/include/builder/dyn_var.h
+++ b/include/builder/dyn_var.h
@@ -234,12 +234,12 @@ public:
 		var_name = v.name;
 	}
 
-	dyn_var_impl(const defer_init&) {
+	dyn_var_impl(const defer_init &) {
 		// Do nothing here
 	}
-	// The function to actually initialize a dyn_var, if it 
+	// The function to actually initialize a dyn_var, if it
 	// has been deferred. It is OKAY to call this even if defer_init
-	// is not used, but is not adviced. This can definitely be called multiple 
+	// is not used, but is not adviced. This can definitely be called multiple
 	// times and will produce the same dyn_var based on the static tag at the
 	// time of this call
 	// Currently we don't support init val, but can be added if needed

--- a/include/util/tracer.h
+++ b/include/util/tracer.h
@@ -58,6 +58,33 @@ public:
 
 		return output_string;
 	}
+
+	std::string stringify_loc(void) {
+		std::string output_string = "[";
+		for (unsigned int i = 0; i < pointers.size(); i++) {
+			char temp[128];
+			sprintf(temp, "%llx", pointers[i]);
+			output_string += temp;
+			if (i != pointers.size() - 1)
+				output_string += ", ";
+		}
+		output_string += "]:[";
+		output_string += "]";
+
+		return output_string;
+	}
+	std::string stringify_stat(void) {
+		std::string output_string = "[";
+		output_string += "]:[";
+		for (unsigned int i = 0; i < static_var_snapshots.size(); i++) {
+			output_string += static_var_snapshots[i];
+			if (i != static_var_snapshots.size() - 1)
+				output_string += ", ";
+		}
+		output_string += "]";
+
+		return output_string;
+	}
 };
 
 tag get_unique_tag(void);

--- a/samples/outputs.var_names/sample40
+++ b/samples/outputs.var_names/sample40
@@ -1,7 +1,7 @@
 #include <string.h>
 int match_re (char* arg1) {
   int var3;
-  int var5;
+  int var4;
   int str_len_1 = strlen(arg1);
   int to_match_2 = 0;
   if (to_match_2 < str_len_1) {
@@ -27,13 +27,14 @@ int match_re (char* arg1) {
                 var3 = 0;
                 return var3;
               } 
-              return 1;
+              var4 = 1;
+              return var4;
             } 
             var3 = 0;
             return var3;
           } 
-          var5 = 0;
-          return var5;
+          var4 = 0;
+          return var4;
         } 
         if (arg1[to_match_2] == 100) {
           goto label2;
@@ -41,13 +42,13 @@ int match_re (char* arg1) {
         var3 = 0;
         return var3;
       } 
-      var5 = 0;
-      return var5;
+      var4 = 0;
+      return var4;
     } 
     var3 = 0;
     return var3;
   } 
-  var5 = 0;
-  return var5;
+  var4 = 0;
+  return var4;
 }
 

--- a/samples/outputs.var_names/sample48
+++ b/samples/outputs.var_names/sample48
@@ -5,22 +5,38 @@ FUNC_DECL
       SCALAR_TYPE (INT)
       VAR (x_0)
       NO_INITIALIZATION
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (var1)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (var2)
+      INT_CONST (0)
+    EXPR_STMT
+      ASSIGN_EXPR
+        VAR_EXPR
+          VAR (var1)
+        INT_CONST (1)
     WHILE_STMT
       INT_CONST (1)
       STMT_BLOCK
         DECL_STMT
           SCALAR_TYPE (INT)
-          VAR (var1)
+          VAR (var3)
           INT_CONST (1)
         DECL_STMT
           SCALAR_TYPE (INT)
-          VAR (var2)
+          VAR (var4)
           INT_CONST (2)
 void my_bar (void) {
   int x_0;
+  int var1 = 0;
+  int var2 = 0;
+  var1 = 1;
   while (1) {
-    int var1 = 1;
-    int var2 = 2;
+    int var3 = 1;
+    int var4 = 2;
   }
 }
 

--- a/samples/outputs.var_names/sample52
+++ b/samples/outputs.var_names/sample52
@@ -1,49 +1,66 @@
 int isEven (int arg0) {
+  int var1;
   if (arg0 == 0) {
-    return 1;
+    var1 = 1;
+    return var1;
   } 
   if (arg0 == 1) {
-    return 0;
+    var1 = 0;
+    return var1;
   } 
   if (arg0 == 2) {
-    return 1;
+    var1 = 1;
+    return var1;
   } 
   if (arg0 == 3) {
-    return 0;
+    var1 = 0;
+    return var1;
   } 
   if (arg0 == 4) {
-    return 1;
+    var1 = 1;
+    return var1;
   } 
   if (arg0 == 5) {
-    return 0;
+    var1 = 0;
+    return var1;
   } 
   if (arg0 == 6) {
-    return 1;
+    var1 = 1;
+    return var1;
   } 
   if (arg0 == 7) {
-    return 0;
+    var1 = 0;
+    return var1;
   } 
   if (arg0 == 8) {
-    return 1;
+    var1 = 1;
+    return var1;
   } 
   if (arg0 == 9) {
-    return 0;
+    var1 = 0;
+    return var1;
   } 
   if (arg0 == 10) {
-    return 1;
+    var1 = 1;
+    return var1;
   } 
   if (arg0 == 11) {
-    return 0;
+    var1 = 0;
+    return var1;
   } 
   if (arg0 == 12) {
-    return 1;
+    var1 = 1;
+    return var1;
   } 
   if (arg0 == 13) {
-    return 0;
+    var1 = 0;
+    return var1;
   } 
   if (arg0 == 14) {
-    return 1;
+    var1 = 1;
+    return var1;
   } 
-  return 0;
+  var1 = 0;
+  return var1;
 }
 

--- a/samples/outputs.var_names/sample54
+++ b/samples/outputs.var_names/sample54
@@ -1,0 +1,12 @@
+void bar (void) {
+  int z_1;
+  int y_0 = 0;
+  if (y_0) {
+    z_1 = 1;
+  } else {
+    z_1 = 2;
+  }
+  int b_2;
+  int a_3 = z_1;
+}
+

--- a/samples/outputs/sample40
+++ b/samples/outputs/sample40
@@ -1,7 +1,7 @@
 #include <string.h>
 int match_re (char* arg1) {
   int var3;
-  int var5;
+  int var4;
   int var1 = strlen(arg1);
   int var2 = 0;
   if (var2 < var1) {
@@ -27,13 +27,14 @@ int match_re (char* arg1) {
                 var3 = 0;
                 return var3;
               } 
-              return 1;
+              var4 = 1;
+              return var4;
             } 
             var3 = 0;
             return var3;
           } 
-          var5 = 0;
-          return var5;
+          var4 = 0;
+          return var4;
         } 
         if (arg1[var2] == 100) {
           goto label2;
@@ -41,13 +42,13 @@ int match_re (char* arg1) {
         var3 = 0;
         return var3;
       } 
-      var5 = 0;
-      return var5;
+      var4 = 0;
+      return var4;
     } 
     var3 = 0;
     return var3;
   } 
-  var5 = 0;
-  return var5;
+  var4 = 0;
+  return var4;
 }
 

--- a/samples/outputs/sample48
+++ b/samples/outputs/sample48
@@ -5,22 +5,38 @@ FUNC_DECL
       SCALAR_TYPE (INT)
       VAR (var0)
       NO_INITIALIZATION
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (var1)
+      INT_CONST (0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (var2)
+      INT_CONST (0)
+    EXPR_STMT
+      ASSIGN_EXPR
+        VAR_EXPR
+          VAR (var1)
+        INT_CONST (1)
     WHILE_STMT
       INT_CONST (1)
       STMT_BLOCK
         DECL_STMT
           SCALAR_TYPE (INT)
-          VAR (var1)
+          VAR (var3)
           INT_CONST (1)
         DECL_STMT
           SCALAR_TYPE (INT)
-          VAR (var2)
+          VAR (var4)
           INT_CONST (2)
 void my_bar (void) {
   int var0;
+  int var1 = 0;
+  int var2 = 0;
+  var1 = 1;
   while (1) {
-    int var1 = 1;
-    int var2 = 2;
+    int var3 = 1;
+    int var4 = 2;
   }
 }
 

--- a/samples/outputs/sample52
+++ b/samples/outputs/sample52
@@ -1,49 +1,66 @@
 int isEven (int arg0) {
+  int var1;
   if (arg0 == 0) {
-    return 1;
+    var1 = 1;
+    return var1;
   } 
   if (arg0 == 1) {
-    return 0;
+    var1 = 0;
+    return var1;
   } 
   if (arg0 == 2) {
-    return 1;
+    var1 = 1;
+    return var1;
   } 
   if (arg0 == 3) {
-    return 0;
+    var1 = 0;
+    return var1;
   } 
   if (arg0 == 4) {
-    return 1;
+    var1 = 1;
+    return var1;
   } 
   if (arg0 == 5) {
-    return 0;
+    var1 = 0;
+    return var1;
   } 
   if (arg0 == 6) {
-    return 1;
+    var1 = 1;
+    return var1;
   } 
   if (arg0 == 7) {
-    return 0;
+    var1 = 0;
+    return var1;
   } 
   if (arg0 == 8) {
-    return 1;
+    var1 = 1;
+    return var1;
   } 
   if (arg0 == 9) {
-    return 0;
+    var1 = 0;
+    return var1;
   } 
   if (arg0 == 10) {
-    return 1;
+    var1 = 1;
+    return var1;
   } 
   if (arg0 == 11) {
-    return 0;
+    var1 = 0;
+    return var1;
   } 
   if (arg0 == 12) {
-    return 1;
+    var1 = 1;
+    return var1;
   } 
   if (arg0 == 13) {
-    return 0;
+    var1 = 0;
+    return var1;
   } 
   if (arg0 == 14) {
-    return 1;
+    var1 = 1;
+    return var1;
   } 
-  return 0;
+  var1 = 0;
+  return var1;
 }
 

--- a/samples/outputs/sample54
+++ b/samples/outputs/sample54
@@ -1,0 +1,12 @@
+void bar (void) {
+  int var1;
+  int var0 = 0;
+  if (var0) {
+    var1 = 1;
+  } else {
+    var1 = 2;
+  }
+  int var2;
+  int var3 = var1;
+}
+

--- a/samples/sample48.cpp
+++ b/samples/sample48.cpp
@@ -9,6 +9,8 @@ using builder::static_var;
 
 static void foo(void) {
 	dyn_var<int> x;
+	dyn_arr<int, 2> y = {0, 0};
+	y[0] = 1;
 	while (1)
 		dyn_arr<int, 2> z = {1, 2};
 }

--- a/samples/sample53.cpp
+++ b/samples/sample53.cpp
@@ -9,21 +9,20 @@
 using builder::dyn_var;
 using builder::static_var;
 
-
 struct external_object_t {
 	dyn_var<int> member = builder::defer_init();
 };
 
-static void foo(external_object_t &obj) {	
+static void foo(external_object_t &obj) {
 	// Init not
 	obj.member.deferred_init();
-	
+
 	dyn_var<int> x = 0;
 	if (x) {
-		obj.member = 1;	
+		obj.member = 1;
 	} else {
 		obj.member = 2;
-	}	
+	}
 }
 
 int main(int argc, char *argv[]) {

--- a/samples/sample54.cpp
+++ b/samples/sample54.cpp
@@ -1,0 +1,39 @@
+// Include the headers
+#include "blocks/c_code_generator.h"
+#include "builder/dyn_var.h"
+#include "builder/static_var.h"
+#include <iostream>
+
+// Include the BuildIt types
+using builder::dyn_var;
+using builder::static_var;
+
+static void bar(void) {
+	static_var<int> x = 0;
+
+	dyn_var<int> y = 0;
+
+	if (y) {
+		x = 1;
+	} else {
+		x = 2;
+	}
+	// When z is declared, x is in different states
+	dyn_var<int> z = x;
+
+	// Executions can now merge, but z is still in different states
+	x = 0;
+
+	// this declaration forces executions to merge because static tags are the same
+	// merge is triggered by memoization
+	dyn_var<int> b;
+
+	// this statement now has issues because z has forked
+	dyn_var<int> a = z;
+}
+
+int main(int argc, char *argv[]) {
+	block::c_code_generator::generate_code(builder::builder_context().extract_function_ast(bar, "bar"), std::cout,
+					       0);
+	return 0;
+}

--- a/src/blocks/c_code_generator.cpp
+++ b/src/blocks/c_code_generator.cpp
@@ -306,6 +306,7 @@ void c_code_generator::visit(decl_stmt::Ptr a) {
 		a->init_expr->accept(this);
 		oss << ";";
 	}
+	// if (a->decl_var->hasMetadata<int>("escapes_static_scope")) oss << " //" << "escapes_static_scope = 1";
 }
 void c_code_generator::visit(if_stmt::Ptr a) {
 	oss << "if (";

--- a/src/blocks/var_namer.cpp
+++ b/src/blocks/var_namer.cpp
@@ -2,8 +2,31 @@
 #include <algorithm>
 namespace block {
 
+void var_gather_escapes::visit(decl_stmt::Ptr stmt) {
+	if (stmt->decl_var->hasMetadata<int>("escapes_static_scope") &&
+	    stmt->decl_var->getMetadata<int>("escapes_static_scope")) {
+
+		if (!stmt->decl_var->hasMetadata<int>("allow_escape_scope") ||
+		    !stmt->decl_var->getMetadata<int>("allow_escape_scope")) {
+
+			std::string so_loc = stmt->decl_var->static_offset.stringify_loc();
+			if (std::find(escaping_tags.begin(), escaping_tags.end(), so_loc) == escaping_tags.end())
+				escaping_tags.push_back(so_loc);
+		}
+	}
+}
+
+static std::string get_apt_tag(var::Ptr a, std::vector<std::string> escaping_tags) {
+	std::string so_loc = a->static_offset.stringify_loc();
+	if (std::find(escaping_tags.begin(), escaping_tags.end(), so_loc) != escaping_tags.end())
+		return so_loc;
+	else
+		return a->static_offset.stringify();
+}
+
 void var_namer::visit(decl_stmt::Ptr stmt) {
-	std::string so = stmt->decl_var->static_offset.stringify();
+	std::string so = get_apt_tag(stmt->decl_var, escaping_tags);
+
 	if (collected_decls.find(so) != collected_decls.end()) {
 		// This decl has been seen before, and needs to be marked for hoisting
 		decls_to_hoist[so] = stmt;
@@ -30,14 +53,15 @@ void var_namer::visit(decl_stmt::Ptr stmt) {
 }
 
 void var_replacer::visit(var_expr::Ptr a) {
-	std::string so = a->var1->static_offset.stringify();
+	std::string so = get_apt_tag(a->var1, escaping_tags);
+
 	if (collected_decls.find(so) != collected_decls.end()) {
 		a->var1 = collected_decls[so];
 	}
 }
 
 void var_hoister::visit(decl_stmt::Ptr a) {
-	std::string so = a->decl_var->static_offset.stringify();
+	std::string so = get_apt_tag(a->decl_var, escaping_tags);
 	if (decls_to_hoist.find(so) != decls_to_hoist.end()) {
 		// This decl needs to be flattened into an assignment
 		// but if it doesn't have an init_expr, just make a simple var_expr
@@ -51,6 +75,7 @@ void var_hoister::visit(decl_stmt::Ptr a) {
 
 		if (a->init_expr == nullptr) {
 			estmt->expr1 = vexpr;
+			node = estmt;
 			return;
 		} else {
 			assign_expr::Ptr assign = std::make_shared<assign_expr>();
@@ -69,12 +94,16 @@ void var_hoister::visit(decl_stmt::Ptr a) {
 
 void var_namer::name_vars(block::Ptr a) {
 	var_namer namer;
+
+	var_gather_escapes gatherer(namer.escaping_tags);
+	a->accept(&gatherer);
+
 	a->accept(&namer);
 
-	var_replacer replacer(namer.collected_decls);
+	var_replacer replacer(namer.collected_decls, namer.escaping_tags);
 	a->accept(&replacer);
 
-	var_hoister hoister(namer.decls_to_hoist);
+	var_hoister hoister(namer.decls_to_hoist, namer.escaping_tags);
 	a->accept(&hoister);
 
 	std::vector<stmt::Ptr> new_stmts;

--- a/src/builder/builder.cpp
+++ b/src/builder/builder.cpp
@@ -46,7 +46,6 @@ builder::builder(const var &a) {
 	block_expr = nullptr;
 
 	tracer::tag offset = get_offset_in_function();
-
 	if (a.current_state == var::member_var) {
 		assert(a.parent_var != nullptr);
 		builder parent_expr_builder = (builder)(*a.parent_var);
@@ -65,6 +64,9 @@ builder::builder(const var &a) {
 		// It should be removed when it is used
 	} else if (a.current_state == var::standalone_var) {
 		assert(a.block_var != nullptr);
+		if (a.block_var->static_offset.stringify_stat() != offset.stringify_stat()) {
+			a.block_var->setMetadata<int>("escapes_static_scope", 1);
+		}
 		block::var_expr::Ptr var_expr = std::make_shared<block::var_expr>();
 		var_expr->static_offset = offset;
 

--- a/src/builder/builder_context.cpp
+++ b/src/builder/builder_context.cpp
@@ -463,5 +463,4 @@ block::stmt::Ptr builder_context::extract_ast_from_function_internal(std::vector
 	return ret_ast;
 }
 
-
 } // namespace builder

--- a/src/builder/builder_context_support.cpp
+++ b/src/builder/builder_context_support.cpp
@@ -13,10 +13,9 @@ void lambda_wrapper(std::function<void(void)> f) {
 }
 void lambda_wrapper_close(void) {}
 
-
 void coroutine_wrapper(std::function<void(void)> f) {
 	f();
-	tail_call_guard +=1;
+	tail_call_guard += 1;
 }
 void coroutine_wrapper_close(void) {}
 } // namespace builder


### PR DESCRIPTION
…rent names

BuildIt has had a bug with assimilating equivalent variables for a long time. The bug was very rare but shows up when using coroutines with BuildIt. New sample54 demonstrates the bug. 

```
static void bar(void) {
	static_var<int> x = 0;

	dyn_var<int> y = 0;

	if (y) {
		x = 1;
	} else {
		x = 2;
	}
	// When z is declared, x is in different states
	dyn_var<int> z = x;

	// Executions can now merge, but z is still in different states
	x = 0;

	// this declaration forces executions to merge because static tags are the same
	// merge is triggered by memoization
	dyn_var<int> b;

	// this statement now has issues because z has forked
	dyn_var<int> a = z;
}
````

would originally produce - 

```
void bar (void) {
  int y_0 = 0;
  if (y_0) {
   int z_1 = 1;
  } else {
   int z_2 = 2;
  }
  int b_2;
  int a_3 = z_1;
}
```

This happens when the same variable is created with different static tags on separate runs (due to static variable being set inside a branch). This creates a problem when the static var state converges. Since all static variables and static locations are the same, BuildIt happily merges execution from this point onwards. But only one of the two copies of the variable is used which either produces code that doesn't compile or misses updates to variables. 

A somewhat simple fix is to identify variables based only on their static location and not the entire tag. This change combined with existing variable hoisting makes sure that the variable is declared upfront and set separately on the two branches. This makes sure that the changes are recorded properly. This simple fix however causes unnecessary merging and hoisting of variables that do not escape the static scope. 

As a work around, we now identify variables that escape the scope. This is done by matching the static state at use and decl. Variables that escape static scope get a special metadata. Var Namer then looks for this metadata and any variable with this metadata is identified purely on the basis on static location and not the entire static tag. Thus variables are only merged and hoisted when absolutely necessary. 

Finally, this creates a problem with `dyn_arr<T>` since they are _supposed_ to escape the scope of their declarations. Remember `dyn_arr<T>` are heap allocated and the constructor is called with a static_var loop. To get around this elements in `dyn_arr<T>` get another metadata that allows them to escape static scope. These variables are identified on the basis on their entire static tag. 

With the changes the sample above now produces - 

```
void bar (void) {
  int z_1;
  int y_0 = 0;
  if (y_0) {
    z_1 = 1;
  } else {
    z_1 = 2;
  }
  int b_2;
  int a_3 = z_1;
}
```

TODO: Investigate if `dyn_arr<T>` could have forking issues and fix if necessary. 