### PR TITLE
Fixed var hoister to convert reference types to pointer types when hoisting

### DIFF
--- a/include/blocks/block.h
+++ b/include/blocks/block.h
@@ -95,6 +95,9 @@ public:
 		typename block_metadata::Ptr mdnode = metadata_map[mdname];
 		return mdnode->to<T>()->val;
 	}
+	bool getBoolMetadata(std::string mdname) {
+		return hasMetadata<bool>(mdname) && getMetadata<bool>(mdname);
+	}
 
 	virtual void dump(std::ostream &, int);
 	virtual void accept(block_visitor *visitor) {

--- a/include/blocks/var_namer.h
+++ b/include/blocks/var_namer.h
@@ -52,7 +52,7 @@ public:
 	virtual void visit(decl_stmt::Ptr) override;
 };
 
-class var_reference_promoter: public block_replacer {
+class var_reference_promoter : public block_replacer {
 public:
 	using block_replacer::visit;
 	virtual void visit(var_expr::Ptr) override;

--- a/include/blocks/var_namer.h
+++ b/include/blocks/var_namer.h
@@ -52,6 +52,12 @@ public:
 	virtual void visit(decl_stmt::Ptr) override;
 };
 
+class var_reference_promoter: public block_replacer {
+public:
+	using block_replacer::visit;
+	virtual void visit(var_expr::Ptr) override;
+};
+
 } // namespace block
 
 #endif

--- a/samples/outputs.var_names/sample54
+++ b/samples/outputs.var_names/sample54
@@ -1,12 +1,18 @@
 void bar (void) {
-  int z_1;
+  int z_3;
+  int* k_4;
   int y_0 = 0;
+  int m_1;
+  int n_2;
   if (y_0) {
-    z_1 = 1;
+    z_3 = 1;
+    k_4 = (&(m_1));
   } else {
-    z_1 = 2;
+    z_3 = 2;
+    k_4 = (&(m_1));
   }
-  int b_2;
-  int a_3 = z_1;
+  int b_5;
+  int a_6 = z_3;
+  z_3 = z_3 + k_4[0];
 }
 

--- a/samples/outputs/sample54
+++ b/samples/outputs/sample54
@@ -1,12 +1,18 @@
 void bar (void) {
-  int var1;
+  int var3;
+  int* var4;
   int var0 = 0;
-  if (var0) {
-    var1 = 1;
-  } else {
-    var1 = 2;
-  }
+  int var1;
   int var2;
-  int var3 = var1;
+  if (var0) {
+    var3 = 1;
+    var4 = (&(var1));
+  } else {
+    var3 = 2;
+    var4 = (&(var1));
+  }
+  int var5;
+  int var6 = var3;
+  var3 = var3 + var4[0];
 }
 

--- a/samples/sample54.cpp
+++ b/samples/sample54.cpp
@@ -21,7 +21,7 @@ static void bar(void) {
 	}
 	// When z is declared, x is in different states
 	dyn_var<int> z = x;
-	dyn_var<int&> k = m;
+	dyn_var<int &> k = m;
 
 	// Executions can now merge, but z is still in different states
 	x = 0;
@@ -34,8 +34,6 @@ static void bar(void) {
 	dyn_var<int> a = z;
 
 	z = z + k;
-
-
 }
 
 int main(int argc, char *argv[]) {

--- a/samples/sample54.cpp
+++ b/samples/sample54.cpp
@@ -12,6 +12,7 @@ static void bar(void) {
 	static_var<int> x = 0;
 
 	dyn_var<int> y = 0;
+	dyn_var<int> m, n;
 
 	if (y) {
 		x = 1;
@@ -20,6 +21,7 @@ static void bar(void) {
 	}
 	// When z is declared, x is in different states
 	dyn_var<int> z = x;
+	dyn_var<int&> k = m;
 
 	// Executions can now merge, but z is still in different states
 	x = 0;
@@ -30,6 +32,10 @@ static void bar(void) {
 
 	// this statement now has issues because z has forked
 	dyn_var<int> a = z;
+
+	z = z + k;
+
+
 }
 
 int main(int argc, char *argv[]) {

--- a/src/blocks/loop_finder.cpp
+++ b/src/blocks/loop_finder.cpp
@@ -228,7 +228,7 @@ void loop_finder::visit_label(label_stmt::Ptr a, stmt_block::Ptr parent) {
 		// this currently happens when two statements have the same tag
 		// For now we will just delete this label
 		std::vector<stmt::Ptr> new_stmts;
-		for (auto stmt: parent->stmts) {
+		for (auto stmt : parent->stmts) {
 			if (stmt == a)
 				continue;
 			new_stmts.push_back(stmt);

--- a/src/blocks/loop_finder.cpp
+++ b/src/blocks/loop_finder.cpp
@@ -222,6 +222,21 @@ void loop_finder::visit_label(label_stmt::Ptr a, stmt_block::Ptr parent) {
 		if (jump_finder.has_jump_to == true)
 			last_stmt = stmt;
 	}
+
+	if (last_stmt == nullptr) {
+		// This label was created but has no jump.
+		// this currently happens when two statements have the same tag
+		// For now we will just delete this label
+		std::vector<stmt::Ptr> new_stmts;
+		for (auto stmt: parent->stmts) {
+			if (stmt == a)
+				continue;
+			new_stmts.push_back(stmt);
+		}
+		parent->stmts = new_stmts;
+		return;
+	}
+
 	std::vector<stmt::Ptr>::iterator stmt;
 	for (stmt = parent->stmts.begin(); stmt != parent->stmts.end(); stmt++) {
 		if (*stmt == a)

--- a/src/blocks/var_namer.cpp
+++ b/src/blocks/var_namer.cpp
@@ -64,7 +64,7 @@ void var_hoister::visit(decl_stmt::Ptr a) {
 	std::string so = get_apt_tag(a->decl_var, escaping_tags);
 	if (decls_to_hoist.find(so) != decls_to_hoist.end()) {
 
-		// if the variable is of reference type, we need to convert it to a pointer 
+		// if the variable is of reference type, we need to convert it to a pointer
 		// type
 
 		if (isa<reference_type>(a->decl_var->var_type)) {
@@ -82,7 +82,6 @@ void var_hoister::visit(decl_stmt::Ptr a) {
 			addr_expr->expr1 = a->init_expr;
 			a->init_expr = addr_expr;
 		}
-
 
 		// This decl needs to be flattened into an assignment
 		// but if it doesn't have an init_expr, just make a simple var_expr
@@ -119,7 +118,7 @@ void var_hoister::visit(decl_stmt::Ptr a) {
 // to dereferences since they have been converted to pointers
 void var_reference_promoter::visit(var_expr::Ptr a) {
 	node = a;
-	if (a->getBoolMetadata("is_reference_init") || !a->var1->getBoolMetadata("was_reference")) 
+	if (a->getBoolMetadata("is_reference_init") || !a->var1->getBoolMetadata("was_reference"))
 		return;
 	auto sq_bkt = std::make_shared<sq_bkt_expr>();
 	sq_bkt->static_offset = a->static_offset;
@@ -131,9 +130,7 @@ void var_reference_promoter::visit(var_expr::Ptr a) {
 
 	sq_bkt->index = index;
 	node = sq_bkt;
-
 }
-
 
 void var_namer::name_vars(block::Ptr a) {
 	var_namer namer;
@@ -148,7 +145,6 @@ void var_namer::name_vars(block::Ptr a) {
 
 	var_hoister hoister(namer.decls_to_hoist, namer.escaping_tags);
 	a->accept(&hoister);
-
 
 	var_reference_promoter promoter;
 	a->accept(&promoter);


### PR DESCRIPTION
This is small change to var hoister to take care of changing types of reference types when hoisting. This wasn't required before because we didn't have reference types. 

Also fixes a small bug in loop_finder when dealing with 2 labels with the same static tags. 

sample54 updated to check for reference types. 