### PR TITLE
Added support for D2X debugging

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/d2x"]
+	path = deps/d2x
+	url = https://github.com/BuildIt-lang/d2x.git

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ all: executables
 
 CHECK_CONFIG=1
 CONFIG_STR=DEBUG=$(DEBUG) RECOVER_VAR_NAMES=$(RECOVER_VAR_NAMES) TRACER_USE_LIBUNWIND=$(TRACER_USE_LIBUNWIND)
-CONFIG_STR+=EXTRA_CFLAGS=$(EXTRA_CFLAGS)
+CONFIG_STR+=EXTRA_CFLAGS=$(EXTRA_CFLAGS) ENABLE_D2X=$(ENABLE_D2X)
 
 
 # Create a scratch directory where the files are stored
@@ -19,6 +19,7 @@ $(shell mkdir -p $(BASE_DIR)/scratch)
 include make/pkgconfig.mk
 include make/format.mk
 include make/stable_config.mk
+include make/deps.mk
 include make/buildit_rules.mk
 include make/tests.mk
 

--- a/include/blocks/c_code_generator.h
+++ b/include/blocks/c_code_generator.h
@@ -1,5 +1,11 @@
 #ifndef C_CODE_GENERATOR_H
 #define C_CODE_GENERATOR_H
+
+#ifdef ENABLE_D2X
+#include "d2x/d2x.h"
+#include "d2x/utils.h"
+#endif
+
 #include "blocks/block_visitor.h"
 #include "blocks/stmt.h"
 #include "builder/dyn_var.h"
@@ -18,6 +24,14 @@ public:
 	std::ostream &oss;
 	int curr_indent = 0;
 	bool decl_only = false;
+	bool use_d2x = false;
+
+#ifdef ENABLE_D2X
+	d2x::d2x_context xctx;
+#endif
+	void save_static_info(block::Ptr a);
+	void nextl(void);
+
 	virtual void visit(not_expr::Ptr);
 	virtual void visit(and_expr::Ptr);
 	virtual void visit(bitwise_and_expr::Ptr);
@@ -73,6 +87,17 @@ public:
 
 	static void generate_code(block::Ptr ast, std::ostream &oss, int indent = 0, bool decl_only = false) {
 		c_code_generator generator(oss);
+		generator.decl_only = decl_only;
+		generator.curr_indent = indent;
+		ast->accept(&generator);
+		oss << std::endl;
+	}
+	static void generate_code_d2x(block::Ptr ast, std::ostream &oss, int indent = 0, bool decl_only = false) {
+#ifndef ENABLE_D2X
+		assert(false && "Cannot generate code with D2X support without ENABLE_D2X build option");
+#endif
+		c_code_generator generator(oss);
+		generator.use_d2x = true;
 		generator.decl_only = decl_only;
 		generator.curr_indent = indent;
 		ast->accept(&generator);

--- a/include/builder/builder_context.h
+++ b/include/builder/builder_context.h
@@ -16,11 +16,17 @@ block::expr::Ptr create_foreign_expr(const T t);
 template <typename T>
 builder create_foreign_expr_builder(const T t);
 
+class static_var_base;
+
 class tracking_tuple {
 public:
 	const unsigned char *ptr;
 	uint32_t size;
-	tracking_tuple(const unsigned char *_ptr, uint32_t _size) : ptr(_ptr), size(_size) {}
+	static_var_base *var_ref;
+
+	tracking_tuple(const unsigned char *_ptr, uint32_t _size, static_var_base *_var_ref)
+	    : ptr(_ptr), size(_size), var_ref(_var_ref) {}
+
 	std::string snapshot(void) {
 		std::string output_string;
 		char temp[4];
@@ -71,6 +77,7 @@ public:
 	bool dynamic_use_cxx = false;
 	std::string dynamic_compiler_flags = "";
 	std::string dynamic_header_includes = "";
+	bool enable_d2x = false;
 
 	bool is_visited_tag(tracer::tag &new_tag);
 	void erase_tag(tracer::tag &erase_tag);

--- a/include/util/tracer.h
+++ b/include/util/tracer.h
@@ -15,6 +15,7 @@ class tag {
 public:
 	std::vector<unsigned long long> pointers;
 	std::vector<std::string> static_var_snapshots;
+	std::vector<std::pair<std::string, std::string>> static_var_key_values;
 
 	bool operator==(const tag &other) {
 		if (other.pointers.size() != pointers.size())

--- a/make/buildit_rules.mk
+++ b/make/buildit_rules.mk
@@ -8,16 +8,16 @@ $(BUILD_DIR)/gen_headers/gen/compiler_headers.h:
 	@echo "#define GEN_TEMPLATE_NAME \"$(BASE_DIR)/scratch/code_XXXXXX\"" >> $@
 	@echo "#define COMPILER_PATH \"$(CC)\"" >> $@
 	@echo "#define CXX_COMPILER_PATH \"$(CXX)\"" >> $@
-$(LIBRARY_OBJS): $(BUILD_DIR)/%.o: $(SRC_DIR)/%.cpp $(INCLUDES)
+$(LIBRARY_OBJS): $(BUILD_DIR)/%.o: $(SRC_DIR)/%.cpp $(INCLUDES) $(DEPS_LIST)
 	@mkdir -p $(@D)
 	$(CXXV) $(CFLAGS_INTERNAL) $(CFLAGS) $< -o $@ $(INCLUDE_FLAGS) -c
-$(BUILD_DIR)/samples/%.o: $(SAMPLES_DIR)/%.cpp $(INCLUDES)
+$(BUILD_DIR)/samples/%.o: $(SAMPLES_DIR)/%.cpp $(INCLUDES) $(DEPS_LIST)
 	@mkdir -p $(@D)
 	$(CXXV) $(CFLAGS_INTERNAL) $(CFLAGS) $< -o $@ $(INCLUDE_FLAGS) -c
-$(LIBRARY): $(LIBRARY_OBJS)
+$(LIBRARY): $(LIBRARY_OBJS) $(DEPS_LIST)
 	@mkdir -p $(@D)
 	$(ARV) cr $(LIBRARY) $(LIBRARY_OBJS)
-$(BUILD_DIR)/sample%: $(BUILD_DIR)/samples/sample%.o $(LIBRARY)
+$(BUILD_DIR)/sample%: $(BUILD_DIR)/samples/sample%.o $(LIBRARY) $(DEPS_LIST)
 	@mkdir -p $(@D)
 	$(CXXLDV) -o $@ $< $(LINKER_FLAGS)
 

--- a/make/deps.mk
+++ b/make/deps.mk
@@ -1,0 +1,8 @@
+# Build dependencies as required
+
+# D2X
+# this d2x.dep is a representative of everything 
+# that d2x provides 
+$(BUILD_DIR)/d2x.dep: $(D2X_DEPS) $(INCLUDES)
+	$(MAKE) -C $(D2X_DIR) BUILDIT_DIR=$(BASE_DIR) lib
+	touch $(BUILD_DIR)/d2x.dep

--- a/make/dirs.mk
+++ b/make/dirs.mk
@@ -20,3 +20,7 @@ UTIL_OBJS=$(subst $(SRC_DIR),$(BUILD_DIR),$(UTIL_SRC:.cpp=.o))
 
 LIBRARY_OBJS=$(BUILDER_OBJS) $(BLOCKS_OBJS) $(UTIL_OBJS) 
 LIBRARY=$(BUILD_DIR)/lib$(LIBRARY_NAME).a
+
+D2X_DIR?=$(BASE_DIR)/deps/d2x
+D2X_BUILD_DIR?=$(D2X_DIR)/build
+D2X_DEPS=$(wildcard $(D2X_DIR)/src/*) $(wildcard $(D2X_DIR)/include/*) $(wildcard $(D2X_DIR)/runtime/*)

--- a/make/format.mk
+++ b/make/format.mk
@@ -3,4 +3,4 @@ CHECK_CONFIG=0
 endif
 
 format:
-	clang-format -i -style=file $$(find -name "*.h" -o -name "*.cpp") 
+	clang-format -i -style=file $$(find \( -name "*.h" -o -name "*.cpp" \) -a -not -path "./deps/*")

--- a/make/setvars.mk
+++ b/make/setvars.mk
@@ -2,6 +2,14 @@
 RECOVER_VAR_NAMES ?= 0
 TRACER_USE_LIBUNWIND ?= 0
 DEBUG ?= 0
+ENABLE_D2X ?= 0
+EXTRA_CFLAGS?=
+
+ifeq ($(ENABLE_D2X),1)
+DEBUG=1
+RECOVER_VAR_NAMES=1
+endif
+
 ifeq ($(RECOVER_VAR_NAMES),1)
 ifneq ($(shell uname), Linux)
 $(error RECOVER_VAR_NAMES only supported on Linux)
@@ -9,14 +17,28 @@ endif
 DEBUG=1
 endif
 
-EXTRA_CFLAGS?=
+
+
+DEPS_LIST=
+LINKER_FLAGS=
+
+ifeq ($(ENABLE_D2X),1)
+LINKER_FLAGS+=-Wl,--start-group -L $(D2X_BUILD_DIR) -ld2x 
+DEPS_LIST+=$(BUILD_DIR)/d2x.dep
+endif
 
 # Create CFLAGS, LINKER_FLAGS, CFLAGS_INTERNAL and INCLUDE_FLAGS based on config
 CFLAGS_INTERNAL=-std=c++11 -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wmissing-declarations 
 CFLAGS_INTERNAL+=-Woverloaded-virtual -Wno-deprecated -Wdelete-non-virtual-dtor -Werror -Wno-vla -pedantic-errors 
 CFLAGS=
-LINKER_FLAGS=-L$(BUILD_DIR)/ -l$(LIBRARY_NAME)
+LINKER_FLAGS+=-L$(BUILD_DIR)/ -l$(LIBRARY_NAME)
 INCLUDE_FLAGS=-I$(INCLUDE_DIR) -I$(BUILD_DIR)/gen_headers/
+
+ifeq ($(ENABLE_D2X),1)
+LINKER_FLAGS+=-Wl,--end-group
+CFLAGS_INTERNAL+=-DENABLE_D2X
+INCLUDE_FLAGS+=-I $(D2X_DIR)/include
+endif
 
 ifeq ($(DEBUG),1)
 CFLAGS+=-g -gdwarf-4
@@ -24,6 +46,8 @@ LINKER_FLAGS+=-g -gdwarf-4
 else
 CFLAGS_INTERNAL+=-O3
 endif
+
+
 
 ifeq ($(TRACER_USE_LIBUNWIND),1)
 CFLAGS_INTERNAL+=-DTRACER_USE_LIBUNWIND

--- a/src/builder/builder_context.cpp
+++ b/src/builder/builder_context.cpp
@@ -271,6 +271,12 @@ block::stmt::Ptr builder_context::extract_ast_from_lambda(std::function<void(voi
 }
 
 block::stmt::Ptr builder_context::extract_ast_from_function_impl(void) {
+
+#ifndef ENABLE_D2X
+	if (enable_d2x)
+		assert(false && "D2X support cannot be enabled without the ENABLE_D2X build option");
+#endif
+
 	std::vector<bool> b;
 
 	block::stmt::Ptr ast = extract_ast_from_function_internal(b);
@@ -349,6 +355,7 @@ block::stmt::Ptr builder_context::extract_ast_from_function_internal(std::vector
 		true_context.visited_offsets = visited_offsets;
 		true_context.internal_stored_lambda = internal_stored_lambda;
 		true_context.feature_unstructured = feature_unstructured;
+		true_context.enable_d2x = enable_d2x;
 
 		std::vector<bool> true_bv;
 		true_bv.push_back(true);
@@ -362,6 +369,7 @@ block::stmt::Ptr builder_context::extract_ast_from_function_internal(std::vector
 		false_context.visited_offsets = visited_offsets;
 		false_context.internal_stored_lambda = internal_stored_lambda;
 		false_context.feature_unstructured = feature_unstructured;
+		false_context.enable_d2x = enable_d2x;
 
 		std::vector<bool> false_bv;
 		false_bv.push_back(false);

--- a/src/util/tracer.cpp
+++ b/src/util/tracer.cpp
@@ -1,5 +1,6 @@
 #include "util/tracer.h"
 #include "builder/builder_context.h"
+#include "builder/static_var.h"
 #include <string>
 
 #ifdef TRACER_USE_LIBUNWIND
@@ -34,6 +35,9 @@ tag get_offset_in_function_impl(builder::builder_context *current_builder_contex
 	assert(current_builder_context != nullptr);
 	for (builder::tracking_tuple tuple : current_builder_context->static_var_tuples) {
 		new_tag.static_var_snapshots.push_back(tuple.snapshot());
+		if (builder::builder_context::current_builder_context->enable_d2x) {
+			new_tag.static_var_key_values.push_back({tuple.var_ref->var_name, tuple.var_ref->serialize()});
+		}
 	}
 	return new_tag;
 }
@@ -57,6 +61,9 @@ tag get_offset_in_function_impl(builder::builder_context *current_builder_contex
 	assert(current_builder_context != nullptr);
 	for (builder::tracking_tuple tuple : current_builder_context->static_var_tuples) {
 		new_tag.static_var_snapshots.push_back(tuple.snapshot());
+		if (builder::builder_context::current_builder_context->enable_d2x) {
+			new_tag.static_var_key_values.push_back({tuple.var_ref->var_name, tuple.var_ref->serialize()});
+		}
 	}
 	return new_tag;
 }


### PR DESCRIPTION
This commit adds a new build flag - ENABLE_D2X. This flag should only be enabled when the submodule deps/d2x is fetched. Enabling this flag builds BuildIt with [D2X](https://buildit.so/d2x) support. D2X is automatically built and linked. 

Just enabling this feature does not change any behavior. To actually use these features, the user can set the `enable_d2x` member in builder_context and use the c_code_generator::generate_code_d2x function instead of the usual c_code_generator::generate_code function. Both functions the same interface. This will dump all the D2X debugging information with the generated code. 

Generated code must be linked with the D2X runtime libraries. 