### PR TITLE
Added support for deferred init static vars

### DIFF
--- a/include/builder/builder_context.h
+++ b/include/builder/builder_context.h
@@ -122,6 +122,7 @@ public:
 	std::string current_label;
 
 	std::vector<tracking_tuple> static_var_tuples;
+	std::vector<tracking_tuple> deferred_static_var_tuples;
 
 	std::vector<var *> assume_variables;
 

--- a/include/builder/dyn_var.h
+++ b/include/builder/dyn_var.h
@@ -90,13 +90,6 @@ struct with_name {
 	with_name(const std::string &n, bool wd = false) : name(n), with_decl(wd) {}
 };
 
-// constructor helper to defer the initialization of dyn_var
-// This allows declaring dyn_var outside the context, but initialize
-// them later
-struct defer_init {
-	// No members
-};
-
 template <typename T>
 class dyn_var_impl : public var {
 public:

--- a/include/builder/forward_declarations.h
+++ b/include/builder/forward_declarations.h
@@ -42,6 +42,13 @@ struct extract_signature;
 template <typename T, typename... OtherArgs>
 struct extract_signature_from_lambda;
 
+// constructor helper to defer the initialization of dyn_var
+// This allows declaring dyn_var outside the context, but initialize
+// them later
+struct defer_init {
+	// No members
+};
+
 // This class does nothing
 // Apart from just being used in the copy constructor to
 // tell the constructor to no create without context

--- a/samples/outputs.var_names/sample53
+++ b/samples/outputs.var_names/sample53
@@ -6,5 +6,35 @@ void foo (void) {
   } else {
     obj_0 = 2;
   }
+  if ((obj_0 % 2) == 0) {
+    obj_0 = obj_0 + 0;
+  } 
+  if ((obj_0 % 2) == 0) {
+    obj_0 = obj_0 + 1;
+  } 
+  if ((obj_0 % 2) == 0) {
+    obj_0 = obj_0 + 2;
+  } 
+  if ((obj_0 % 2) == 0) {
+    obj_0 = obj_0 + 3;
+  } 
+  if ((obj_0 % 2) == 0) {
+    obj_0 = obj_0 + 4;
+  } 
+  if ((obj_0 % 2) == 0) {
+    obj_0 = obj_0 + 5;
+  } 
+  if ((obj_0 % 2) == 0) {
+    obj_0 = obj_0 + 6;
+  } 
+  if ((obj_0 % 2) == 0) {
+    obj_0 = obj_0 + 7;
+  } 
+  if ((obj_0 % 2) == 0) {
+    obj_0 = obj_0 + 8;
+  } 
+  if ((obj_0 % 2) == 0) {
+    obj_0 = obj_0 + 9;
+  } 
 }
 

--- a/samples/outputs/sample53
+++ b/samples/outputs/sample53
@@ -6,5 +6,35 @@ void foo (void) {
   } else {
     var0 = 2;
   }
+  if ((var0 % 2) == 0) {
+    var0 = var0 + 0;
+  } 
+  if ((var0 % 2) == 0) {
+    var0 = var0 + 1;
+  } 
+  if ((var0 % 2) == 0) {
+    var0 = var0 + 2;
+  } 
+  if ((var0 % 2) == 0) {
+    var0 = var0 + 3;
+  } 
+  if ((var0 % 2) == 0) {
+    var0 = var0 + 4;
+  } 
+  if ((var0 % 2) == 0) {
+    var0 = var0 + 5;
+  } 
+  if ((var0 % 2) == 0) {
+    var0 = var0 + 6;
+  } 
+  if ((var0 % 2) == 0) {
+    var0 = var0 + 7;
+  } 
+  if ((var0 % 2) == 0) {
+    var0 = var0 + 8;
+  } 
+  if ((var0 % 2) == 0) {
+    var0 = var0 + 9;
+  } 
 }
 

--- a/samples/sample53.cpp
+++ b/samples/sample53.cpp
@@ -11,11 +11,13 @@ using builder::static_var;
 
 struct external_object_t {
 	dyn_var<int> member = builder::defer_init();
+	static_var<int> counter = builder::defer_init();
 };
 
 static void foo(external_object_t &obj) {
 	// Init not
 	obj.member.deferred_init();
+	obj.counter.deferred_init();
 
 	dyn_var<int> x = 0;
 	if (x) {
@@ -23,6 +25,10 @@ static void foo(external_object_t &obj) {
 	} else {
 		obj.member = 2;
 	}
+
+	for (obj.counter = 0; obj.counter < 10; obj.counter++)
+		if (obj.member % 2 == 0)
+			obj.member += obj.counter;
 }
 
 int main(int argc, char *argv[]) {

--- a/src/builder/builder_context.cpp
+++ b/src/builder/builder_context.cpp
@@ -426,6 +426,7 @@ block::stmt::Ptr builder_context::extract_ast_from_function_internal(std::vector
 		}
 		ret_ast = ast;
 	}
+	current_builder_context = nullptr;
 
 	// Update the memoized table with the stmt block we just created
 	for (unsigned int i = 0; i < current_block_stmt->stmts.size(); i++) {

--- a/src/util/tracer.cpp
+++ b/src/util/tracer.cpp
@@ -33,6 +33,13 @@ tag get_offset_in_function_impl(builder::builder_context *current_builder_contex
 	}
 	// Now add snapshots of static vars
 	assert(current_builder_context != nullptr);
+
+	for (builder::tracking_tuple tuple : current_builder_context->deferred_static_var_tuples) {
+		new_tag.static_var_snapshots.push_back(tuple.snapshot());
+		if (builder::builder_context::current_builder_context->enable_d2x) {
+			new_tag.static_var_key_values.push_back({tuple.var_ref->var_name, tuple.var_ref->serialize()});
+		}
+	}
 	for (builder::tracking_tuple tuple : current_builder_context->static_var_tuples) {
 		new_tag.static_var_snapshots.push_back(tuple.snapshot());
 		if (builder::builder_context::current_builder_context->enable_d2x) {
@@ -59,6 +66,13 @@ tag get_offset_in_function_impl(builder::builder_context *current_builder_contex
 
 	// Now add snapshots of static vars
 	assert(current_builder_context != nullptr);
+
+	for (builder::tracking_tuple tuple : current_builder_context->deferred_static_var_tuples) {
+		new_tag.static_var_snapshots.push_back(tuple.snapshot());
+		if (builder::builder_context::current_builder_context->enable_d2x) {
+			new_tag.static_var_key_values.push_back({tuple.var_ref->var_name, tuple.var_ref->serialize()});
+		}
+	}
 	for (builder::tracking_tuple tuple : current_builder_context->static_var_tuples) {
 		new_tag.static_var_snapshots.push_back(tuple.snapshot());
 		if (builder::builder_context::current_builder_context->enable_d2x) {


### PR DESCRIPTION
This change adds support for deferring inits for static_var with builder::defer_init same as dyn_var. Deferred static vars are added to a separate deferred_static_var_tuples in the builder_context and currently are never removed. 

We can add an option to uninit static vars in the future. Sample53 has been updated to test this. 