### PR TITLE
Changed dyn_var specialization for pointer types to return the appropriate type

### DIFF
--- a/include/builder/builder_base.h
+++ b/include/builder/builder_base.h
@@ -29,7 +29,7 @@ public:
 	virtual ~builder_root() = default;
 };
 
-class builder : builder_root {
+class builder {
 
 	typedef builder BT;
 
@@ -46,7 +46,7 @@ public:
 	// and set the block_expr immediately
 	builder() = default;
 	// Copy constructor from another builder
-	builder(const BT &other) : builder_root() {
+	builder(const BT &other) {
 		block_expr = other.block_expr;
 	}
 

--- a/include/builder/builder_base.h
+++ b/include/builder/builder_base.h
@@ -24,11 +24,6 @@ std::vector<block::expr::Ptr> extract_call_arguments(const arg_types &...args);
 template <typename BT, typename... arg_types>
 std::vector<block::expr::Ptr> extract_call_arguments_helper(const arg_types &...args);
 
-class builder_root {
-public:
-	virtual ~builder_root() = default;
-};
-
 class builder {
 
 	typedef builder BT;
@@ -302,10 +297,6 @@ public:
 		push_to_sequence(block_expr);
 	}
 
-	// This is an overload for the virtual function inside member_base
-	virtual block::expr::Ptr get_parent() const {
-		return this->block_expr;
-	}
 };
 
 void annotate(std::string);

--- a/include/builder/forward_declarations.h
+++ b/include/builder/forward_declarations.h
@@ -13,7 +13,7 @@ class builder;
 struct sentinel_member;
 
 template <typename T>
-using is_builder_type = typename std::is_base_of<builder_root, T>;
+using is_builder_type = typename std::is_same<builder, T>;
 
 template <typename T>
 using if_builder = typename std::enable_if<is_builder_type<T>::value, T>::type;

--- a/samples/outputs.var_names/sample46
+++ b/samples/outputs.var_names/sample46
@@ -57,6 +57,37 @@ FUNC_DECL
         MEMBER_ACCESS_EXPR (member)
           VAR_EXPR
             VAR (g_0)
+    DECL_STMT
+      POINTER_TYPE
+        NAMED_TYPE (FooT)
+      VAR (i_5)
+      NO_INITIALIZATION
+    EXPR_STMT
+      ASSIGN_EXPR
+        MEMBER_ACCESS_EXPR (member)
+          SQ_BKT_EXPR
+            VAR_EXPR
+              VAR (i_5)
+            INT_CONST (0)
+        MEMBER_ACCESS_EXPR (my_member)
+          VAR_EXPR
+            VAR (l_4)
+    EXPR_STMT
+      ASSIGN_EXPR
+        MEMBER_ACCESS_EXPR (member)
+          SQ_BKT_EXPR
+            VAR_EXPR
+              VAR (i_5)
+            INT_CONST (0)
+        INT_CONST (0)
+    EXPR_STMT
+      ASSIGN_EXPR
+        MEMBER_ACCESS_EXPR (member)
+          SQ_BKT_EXPR
+            VAR_EXPR
+              VAR (i_5)
+            INT_CONST (3)
+        INT_CONST (0)
 struct FooT {
   int member;
 };
@@ -74,5 +105,9 @@ void my_bar (void) {
   f_3.second_member = g_0 + 1;
   CarT<int, BarT> l_4;
   l_4.my_member = g_0.member;
+  FooT* i_5;
+  i_5->member = l_4.my_member;
+  i_5->member = 0;
+  (i_5[3]).member = 0;
 }
 

--- a/samples/outputs/sample46
+++ b/samples/outputs/sample46
@@ -57,6 +57,37 @@ FUNC_DECL
         MEMBER_ACCESS_EXPR (member)
           VAR_EXPR
             VAR (var0)
+    DECL_STMT
+      POINTER_TYPE
+        NAMED_TYPE (FooT)
+      VAR (var5)
+      NO_INITIALIZATION
+    EXPR_STMT
+      ASSIGN_EXPR
+        MEMBER_ACCESS_EXPR (member)
+          SQ_BKT_EXPR
+            VAR_EXPR
+              VAR (var5)
+            INT_CONST (0)
+        MEMBER_ACCESS_EXPR (my_member)
+          VAR_EXPR
+            VAR (var4)
+    EXPR_STMT
+      ASSIGN_EXPR
+        MEMBER_ACCESS_EXPR (member)
+          SQ_BKT_EXPR
+            VAR_EXPR
+              VAR (var5)
+            INT_CONST (0)
+        INT_CONST (0)
+    EXPR_STMT
+      ASSIGN_EXPR
+        MEMBER_ACCESS_EXPR (member)
+          SQ_BKT_EXPR
+            VAR_EXPR
+              VAR (var5)
+            INT_CONST (3)
+        INT_CONST (0)
 struct FooT {
   int member;
 };
@@ -74,5 +105,9 @@ void my_bar (void) {
   var3.second_member = var0 + 1;
   CarT<int, BarT> var4;
   var4.my_member = var0.member;
+  FooT* var5;
+  var5->member = var4.my_member;
+  var5->member = 0;
+  (var5[3]).member = 0;
 }
 

--- a/samples/sample38.cpp
+++ b/samples/sample38.cpp
@@ -30,34 +30,7 @@ public:
 	dyn_var<int> member = as_member(this, "member");
 };
 
-// Create specialization for foo_t* so that we can overload the * operator
-
-template <>
-class dyn_var<foo_t *> : public dyn_var_impl<foo_t *> {
-public:
-	typedef dyn_var_impl<foo_t *> super;
-	using super::super;
-	using super::operator=;
-	builder operator=(const dyn_var<foo_t *> &t) {
-		return (*this) = (builder)t;
-	}
-	dyn_var(const dyn_var &t) : dyn_var_impl((builder)t) {}
-	dyn_var() : dyn_var_impl<foo_t *>() {}
-
-	dyn_var<foo_t> operator*() {
-		// Rely on copy elision
-		return (cast)this->operator[](0);
-	}
-
-	// This is POC of how -> operator can
-	// be implemented. Requires the hack of creating a dummy
-	// member because -> needs to return a pointer.
-	dyn_var<foo_t> _p = as_member(this, "_p");
-	dyn_var<foo_t> *operator->() {
-		_p = (cast)this->operator[](0);
-		return _p.addr();
-	}
-};
+/* Specialization for foo_t* is not required because it comes built in with dyn_var now */
 
 } // namespace builder
 

--- a/samples/sample46.cpp
+++ b/samples/sample46.cpp
@@ -38,6 +38,11 @@ static void bar(void) {
 
 	dyn_var<CarT<int, BarT<float>>> l;
 	l.my_member = g.member;
+
+	dyn_var<FooT *> i;
+	i->member = l.my_member;
+	(*i).member = 0;
+	i[3].member = 0;
 }
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
Previously all dyn_var returned a plain old builder for the *, [] operators. But this makes accessing members from custom types difficulty.

We have now changed the specialization for all pointer types T* to return a dyn_var<T> with the expression inside for * and []. Further more we add an implementation of -> for these types similar to how it was implemented in sample38

sample38 has been updated to not require a separate specialization for dyn_var<foo_t*> anymore. sample46 also has been updated to test the new feature. 

