### PR TITLE
Cleanup dyn_var helper types, constructors and operators

### DIFF
--- a/include/builder/builder.h
+++ b/include/builder/builder.h
@@ -5,7 +5,6 @@
 
 namespace builder {
 
-struct sentinel_member {};
 
 } // namespace builder
 

--- a/include/builder/builder_base.h
+++ b/include/builder/builder_base.h
@@ -31,7 +31,6 @@ class builder {
 public:
 	// All members here
 	block::expr::Ptr block_expr;
-	static BT sentinel_builder;
 
 	typedef builder super;
 

--- a/include/builder/builder_context.h
+++ b/include/builder/builder_context.h
@@ -128,8 +128,7 @@ public:
 
 	template <typename T>
 	T *assume_variable(std::string name) {
-		T *new_asm_variable = new T(dyn_var_sentinel_type());
-		new_asm_variable->block_var->var_name = name;
+		T * new_asm_variable = new T(with_name(name));
 		assume_variables.push_back(new_asm_variable);
 
 		return new_asm_variable;

--- a/include/builder/dyn_var.h
+++ b/include/builder/dyn_var.h
@@ -79,17 +79,6 @@ struct as_compound_expr {
 };
 using cast = as_compound_expr;
 
-struct as_global {
-	std::string name;
-	as_global(const std::string &n) : name(n) {}
-};
-// With name is just like as_global but can be used locally
-struct with_name {
-	std::string name;
-	bool with_decl;
-	with_name(const std::string &n, bool wd = false) : name(n), with_decl(wd) {}
-};
-
 template <typename T>
 class dyn_var_impl : public var {
 public:

--- a/include/builder/forward_declarations.h
+++ b/include/builder/forward_declarations.h
@@ -10,8 +10,6 @@ class builder_root;
 // The builder base class
 class builder;
 
-struct sentinel_member;
-
 template <typename T>
 using is_builder_type = typename std::is_same<builder, T>;
 
@@ -49,18 +47,7 @@ struct defer_init {
 	// No members
 };
 
-// This class does nothing
-// Apart from just being used in the copy constructor to
-// tell the constructor to no create without context
-struct dyn_var_sentinel_type {};
+struct with_name;
 
-// This class is used for creating exact replicas of a variable
-// One possible use if when initializing args for func_decls
-class dyn_var_consume {
-public:
-	block::var::Ptr block_var = nullptr;
-	dyn_var_consume(const var &a);
-	dyn_var_consume(const dyn_var_consume &);
-};
 } // namespace builder
 #endif

--- a/include/builder/forward_declarations.h
+++ b/include/builder/forward_declarations.h
@@ -47,7 +47,19 @@ struct defer_init {
 	// No members
 };
 
-struct with_name;
+
+// Constructor helpers for dyn_var
+struct as_global {
+	std::string name;
+	as_global(const std::string &n) : name(n) {}
+};
+// With name is just like as_global but can be used locally
+struct with_name {
+	std::string name;
+	bool with_decl;
+	with_name(const std::string &n, bool wd = false) : name(n), with_decl(wd) {}
+};
+
 
 } // namespace builder
 #endif

--- a/include/builder/operator_overload.h
+++ b/include/builder/operator_overload.h
@@ -19,7 +19,7 @@ struct return_type_helper<T, typename std::enable_if<is_builder_type<T>::value>:
 };
 template <typename T>
 struct return_type_helper<T, typename std::enable_if<!is_builder_type<T>::value && is_dyn_var_type<T>::value>::type> {
-	typedef typename T::associated_BT type;
+	typedef builder type;
 };
 
 template <typename T1, typename T2, class Enable = void>

--- a/include/builder/signature_extract.h
+++ b/include/builder/signature_extract.h
@@ -15,6 +15,7 @@ struct peel_dyn<T, typename std::enable_if<std::is_base_of<var, T>::value>::type
 	typedef typename T::stored_type type;
 };
 
+
 struct extract_signature_enable;
 template <typename T, class Enable = void>
 struct filter_var_type {

--- a/src/builder/builder.cpp
+++ b/src/builder/builder.cpp
@@ -14,14 +14,6 @@ std::vector<block::type::Ptr> extract_type_vector_dyn<>(void) {
 	return empty_vector;
 }
 
-dyn_var_consume::dyn_var_consume(const var &a) {
-	block_var = a.block_var;
-}
-dyn_var_consume::dyn_var_consume(const dyn_var_consume &a) {
-	block_var = a.block_var;
-}
-
-builder builder::sentinel_builder;
 void create_return_stmt(const builder &a) {
 
 	builder_context::current_builder_context->remove_node_from_sequence(a.block_expr);


### PR DESCRIPTION
This commit simplifies the implementation of the dyn_var (dyn_var_impl) by merging trivial constructors (that defer to builder), operators with templated versions. We also remove unused constructor helpers like dyn_var_sentinel_type. 

No change in functionality or new samples