### PR TITLE
Added support for with_name with deferred_init and disabled hoisting …

### DIFF
--- a/include/builder/dyn_var.h
+++ b/include/builder/dyn_var.h
@@ -184,6 +184,13 @@ public:
 	void deferred_init(void) {
 		create_dyn_var(false);
 	}
+	// This version allows deferred init to accept other constructor helpers
+	void deferred_init(const with_name &v) {
+		create_dyn_var(!v.with_decl);
+		block_var->var_name = v.name;
+		block_var->preferred_name = "";
+		var_name = v.name;
+	}
 	// Constructor to initialize a dyn_var as member
 	// This declaration does not produce a declaration
 	dyn_var_impl(const as_member &a) {

--- a/samples/outputs.var_names/sample40
+++ b/samples/outputs.var_names/sample40
@@ -1,7 +1,7 @@
 #include <string.h>
 int match_re (char* arg1) {
   int var3;
-  int var4;
+  int var5;
   int str_len_1 = strlen(arg1);
   int to_match_2 = 0;
   if (to_match_2 < str_len_1) {
@@ -27,14 +27,13 @@ int match_re (char* arg1) {
                 var3 = 0;
                 return var3;
               } 
-              var4 = 1;
-              return var4;
+              return 1;
             } 
             var3 = 0;
             return var3;
           } 
-          var4 = 0;
-          return var4;
+          var5 = 0;
+          return var5;
         } 
         if (arg1[to_match_2] == 100) {
           goto label2;
@@ -42,13 +41,13 @@ int match_re (char* arg1) {
         var3 = 0;
         return var3;
       } 
-      var4 = 0;
-      return var4;
+      var5 = 0;
+      return var5;
     } 
     var3 = 0;
     return var3;
   } 
-  var4 = 0;
-  return var4;
+  var5 = 0;
+  return var5;
 }
 

--- a/samples/outputs.var_names/sample52
+++ b/samples/outputs.var_names/sample52
@@ -1,66 +1,49 @@
 int isEven (int arg0) {
-  int var1;
   if (arg0 == 0) {
-    var1 = 1;
-    return var1;
+    return 1;
   } 
   if (arg0 == 1) {
-    var1 = 0;
-    return var1;
+    return 0;
   } 
   if (arg0 == 2) {
-    var1 = 1;
-    return var1;
+    return 1;
   } 
   if (arg0 == 3) {
-    var1 = 0;
-    return var1;
+    return 0;
   } 
   if (arg0 == 4) {
-    var1 = 1;
-    return var1;
+    return 1;
   } 
   if (arg0 == 5) {
-    var1 = 0;
-    return var1;
+    return 0;
   } 
   if (arg0 == 6) {
-    var1 = 1;
-    return var1;
+    return 1;
   } 
   if (arg0 == 7) {
-    var1 = 0;
-    return var1;
+    return 0;
   } 
   if (arg0 == 8) {
-    var1 = 1;
-    return var1;
+    return 1;
   } 
   if (arg0 == 9) {
-    var1 = 0;
-    return var1;
+    return 0;
   } 
   if (arg0 == 10) {
-    var1 = 1;
-    return var1;
+    return 1;
   } 
   if (arg0 == 11) {
-    var1 = 0;
-    return var1;
+    return 0;
   } 
   if (arg0 == 12) {
-    var1 = 1;
-    return var1;
+    return 1;
   } 
   if (arg0 == 13) {
-    var1 = 0;
-    return var1;
+    return 0;
   } 
   if (arg0 == 14) {
-    var1 = 1;
-    return var1;
+    return 1;
   } 
-  var1 = 0;
-  return var1;
+  return 0;
 }
 

--- a/samples/outputs.var_names/sample53
+++ b/samples/outputs.var_names/sample53
@@ -1,40 +1,40 @@
 void foo (void) {
-  int obj_0;
-  int x_1 = 0;
-  if (x_1) {
-    obj_0 = 1;
+  int member_var;
+  int x_0 = 0;
+  if (x_0) {
+    member_var = 1;
   } else {
-    obj_0 = 2;
+    member_var = 2;
   }
-  if ((obj_0 % 2) == 0) {
-    obj_0 = obj_0 + 0;
+  if ((member_var % 2) == 0) {
+    member_var = member_var + 0;
   } 
-  if ((obj_0 % 2) == 0) {
-    obj_0 = obj_0 + 1;
+  if ((member_var % 2) == 0) {
+    member_var = member_var + 1;
   } 
-  if ((obj_0 % 2) == 0) {
-    obj_0 = obj_0 + 2;
+  if ((member_var % 2) == 0) {
+    member_var = member_var + 2;
   } 
-  if ((obj_0 % 2) == 0) {
-    obj_0 = obj_0 + 3;
+  if ((member_var % 2) == 0) {
+    member_var = member_var + 3;
   } 
-  if ((obj_0 % 2) == 0) {
-    obj_0 = obj_0 + 4;
+  if ((member_var % 2) == 0) {
+    member_var = member_var + 4;
   } 
-  if ((obj_0 % 2) == 0) {
-    obj_0 = obj_0 + 5;
+  if ((member_var % 2) == 0) {
+    member_var = member_var + 5;
   } 
-  if ((obj_0 % 2) == 0) {
-    obj_0 = obj_0 + 6;
+  if ((member_var % 2) == 0) {
+    member_var = member_var + 6;
   } 
-  if ((obj_0 % 2) == 0) {
-    obj_0 = obj_0 + 7;
+  if ((member_var % 2) == 0) {
+    member_var = member_var + 7;
   } 
-  if ((obj_0 % 2) == 0) {
-    obj_0 = obj_0 + 8;
+  if ((member_var % 2) == 0) {
+    member_var = member_var + 8;
   } 
-  if ((obj_0 % 2) == 0) {
-    obj_0 = obj_0 + 9;
+  if ((member_var % 2) == 0) {
+    member_var = member_var + 9;
   } 
 }
 

--- a/samples/outputs/sample40
+++ b/samples/outputs/sample40
@@ -1,7 +1,7 @@
 #include <string.h>
 int match_re (char* arg1) {
   int var3;
-  int var4;
+  int var5;
   int var1 = strlen(arg1);
   int var2 = 0;
   if (var2 < var1) {
@@ -27,14 +27,13 @@ int match_re (char* arg1) {
                 var3 = 0;
                 return var3;
               } 
-              var4 = 1;
-              return var4;
+              return 1;
             } 
             var3 = 0;
             return var3;
           } 
-          var4 = 0;
-          return var4;
+          var5 = 0;
+          return var5;
         } 
         if (arg1[var2] == 100) {
           goto label2;
@@ -42,13 +41,13 @@ int match_re (char* arg1) {
         var3 = 0;
         return var3;
       } 
-      var4 = 0;
-      return var4;
+      var5 = 0;
+      return var5;
     } 
     var3 = 0;
     return var3;
   } 
-  var4 = 0;
-  return var4;
+  var5 = 0;
+  return var5;
 }
 

--- a/samples/outputs/sample52
+++ b/samples/outputs/sample52
@@ -1,66 +1,49 @@
 int isEven (int arg0) {
-  int var1;
   if (arg0 == 0) {
-    var1 = 1;
-    return var1;
+    return 1;
   } 
   if (arg0 == 1) {
-    var1 = 0;
-    return var1;
+    return 0;
   } 
   if (arg0 == 2) {
-    var1 = 1;
-    return var1;
+    return 1;
   } 
   if (arg0 == 3) {
-    var1 = 0;
-    return var1;
+    return 0;
   } 
   if (arg0 == 4) {
-    var1 = 1;
-    return var1;
+    return 1;
   } 
   if (arg0 == 5) {
-    var1 = 0;
-    return var1;
+    return 0;
   } 
   if (arg0 == 6) {
-    var1 = 1;
-    return var1;
+    return 1;
   } 
   if (arg0 == 7) {
-    var1 = 0;
-    return var1;
+    return 0;
   } 
   if (arg0 == 8) {
-    var1 = 1;
-    return var1;
+    return 1;
   } 
   if (arg0 == 9) {
-    var1 = 0;
-    return var1;
+    return 0;
   } 
   if (arg0 == 10) {
-    var1 = 1;
-    return var1;
+    return 1;
   } 
   if (arg0 == 11) {
-    var1 = 0;
-    return var1;
+    return 0;
   } 
   if (arg0 == 12) {
-    var1 = 1;
-    return var1;
+    return 1;
   } 
   if (arg0 == 13) {
-    var1 = 0;
-    return var1;
+    return 0;
   } 
   if (arg0 == 14) {
-    var1 = 1;
-    return var1;
+    return 1;
   } 
-  var1 = 0;
-  return var1;
+  return 0;
 }
 

--- a/samples/outputs/sample53
+++ b/samples/outputs/sample53
@@ -1,40 +1,40 @@
 void foo (void) {
-  int var0;
-  int var1 = 0;
-  if (var1) {
-    var0 = 1;
+  int member_var;
+  int var0 = 0;
+  if (var0) {
+    member_var = 1;
   } else {
-    var0 = 2;
+    member_var = 2;
   }
-  if ((var0 % 2) == 0) {
-    var0 = var0 + 0;
+  if ((member_var % 2) == 0) {
+    member_var = member_var + 0;
   } 
-  if ((var0 % 2) == 0) {
-    var0 = var0 + 1;
+  if ((member_var % 2) == 0) {
+    member_var = member_var + 1;
   } 
-  if ((var0 % 2) == 0) {
-    var0 = var0 + 2;
+  if ((member_var % 2) == 0) {
+    member_var = member_var + 2;
   } 
-  if ((var0 % 2) == 0) {
-    var0 = var0 + 3;
+  if ((member_var % 2) == 0) {
+    member_var = member_var + 3;
   } 
-  if ((var0 % 2) == 0) {
-    var0 = var0 + 4;
+  if ((member_var % 2) == 0) {
+    member_var = member_var + 4;
   } 
-  if ((var0 % 2) == 0) {
-    var0 = var0 + 5;
+  if ((member_var % 2) == 0) {
+    member_var = member_var + 5;
   } 
-  if ((var0 % 2) == 0) {
-    var0 = var0 + 6;
+  if ((member_var % 2) == 0) {
+    member_var = member_var + 6;
   } 
-  if ((var0 % 2) == 0) {
-    var0 = var0 + 7;
+  if ((member_var % 2) == 0) {
+    member_var = member_var + 7;
   } 
-  if ((var0 % 2) == 0) {
-    var0 = var0 + 8;
+  if ((member_var % 2) == 0) {
+    member_var = member_var + 8;
   } 
-  if ((var0 % 2) == 0) {
-    var0 = var0 + 9;
+  if ((member_var % 2) == 0) {
+    member_var = member_var + 9;
   } 
 }
 

--- a/samples/sample53.cpp
+++ b/samples/sample53.cpp
@@ -16,7 +16,7 @@ struct external_object_t {
 
 static void foo(external_object_t &obj) {
 	// Init not
-	obj.member.deferred_init();
+	obj.member.deferred_init(builder::with_name("member_var", true));
 	obj.counter.deferred_init();
 
 	dyn_var<int> x = 0;

--- a/samples/sample54.cpp
+++ b/samples/sample54.cpp
@@ -1,3 +1,5 @@
+/*NO_TEST*/
+/* This feature has been disabled for now. TODO: Enable this test after selective path merging implementation */
 // Include the headers
 #include "blocks/c_code_generator.h"
 #include "builder/dyn_var.h"

--- a/src/blocks/var_namer.cpp
+++ b/src/blocks/var_namer.cpp
@@ -3,6 +3,10 @@
 namespace block {
 
 void var_gather_escapes::visit(decl_stmt::Ptr stmt) {
+	// Disabling escape var analysis 
+	// We are not supporting hoisting of escaped variables now
+	// TODO: Implement this by selecting merging of path based on live dyn vars
+	return;
 	if (stmt->decl_var->hasMetadata<int>("escapes_static_scope") &&
 	    stmt->decl_var->getMetadata<int>("escapes_static_scope")) {
 


### PR DESCRIPTION
…variables that escape static scope

This pull request makes 2 changes - 

1. Adds support for using builder::with_name with deferred_init. This is a simple change that just adds an overload. 
2. Reverts the changes made in #60 . The rationale is as follows - The previous changes causes variables that escape scope to be merged and hoisted up. But this causes issues when dyn_vars or structs containing dyn_vars are heap allocated in a static loop. 
We are defaulting to no hoisting the variables and we can add a metadata if the hoisting behavior is needed. In the future the proper fix would be to selectively merge paths only when the live dynamic variables on both the side are the same. 

TODO: Implement the proper fix. 