### PR TITLE
added support for extracting member names with RECOVER_VAR_NAMES=1

### DIFF
--- a/include/util/var_finder.h
+++ b/include/util/var_finder.h
@@ -4,6 +4,7 @@
 namespace util {
 std::string find_variable_name(void *);
 std::string find_variable_name_cached(void *, std::string tag_string);
+extern std::string member_separator;
 } // namespace util
 
 #endif

--- a/samples/outputs.var_names/sample55
+++ b/samples/outputs.var_names/sample55
@@ -1,0 +1,9 @@
+void bar (void) {
+  int x_0;
+  char x_mem2_1;
+  int y_mem1_2;
+  char y_mem2_3;
+  x_0 = x_mem2_1;
+  y_mem2_3 = y_mem1_2;
+}
+

--- a/samples/outputs/sample55
+++ b/samples/outputs/sample55
@@ -1,0 +1,9 @@
+void bar (void) {
+  int var0;
+  char var1;
+  int var2;
+  char var3;
+  var0 = var1;
+  var3 = var2;
+}
+

--- a/samples/sample55.cpp
+++ b/samples/sample55.cpp
@@ -1,0 +1,38 @@
+// Include the headers
+#include "blocks/c_code_generator.h"
+#include "builder/dyn_var.h"
+#include "builder/static_var.h"
+#include <iostream>
+
+// Include the BuildIt types
+using builder::dyn_var;
+using builder::static_var;
+
+
+// Members of this struct will have names except for the first one
+// since we currently don't match sizes
+struct wrapper1 {
+	dyn_var<int> mem1;
+	dyn_var<char> mem2;
+};
+
+// Members of this struct will have names since the first member is a non dynamic one
+struct wrapper2 {
+	int spacer;
+	dyn_var<int> mem1;
+	dyn_var<char> mem2;
+};
+
+
+static void bar(void) {
+	struct wrapper1 x;
+	struct wrapper2 y;
+	x.mem1 = x.mem2;
+	y.mem2 = y.mem1;
+}
+
+int main(int argc, char *argv[]) {
+	block::c_code_generator::generate_code(
+		builder::builder_context().extract_function_ast(bar, "bar"), std::cout, 0);
+	return 0;
+}


### PR DESCRIPTION
This change only affects the configuration RECOVER_VAR_NAMES=1 (and ENABLE_D2X). Previously when dyn_vars are declared inside structs, they won't get a name because the address doesn't match with the parent object. This change also looks for members of structs that are in scope and checks if any member is at the right offset. 

This should also improve the static var names extraction in ENABLE_D2X. 

Sample55 has been added to test this. 