### PR TITLE
Simplified API for custom types (yet again)

### DIFF
--- a/samples/outputs.var_names/sample56
+++ b/samples/outputs.var_names/sample56
@@ -1,0 +1,57 @@
+FUNC_DECL
+  SCALAR_TYPE (VOID)
+  STMT_BLOCK
+    DECL_STMT
+      NAMED_TYPE (my_type)
+      VAR (a_0)
+      NO_INITIALIZATION
+    DECL_STMT
+      NAMED_TYPE (custom_struct0)
+      VAR (b_1)
+      NO_INITIALIZATION
+    EXPR_STMT
+      ASSIGN_EXPR
+        MEMBER_ACCESS_EXPR (nested)
+          VAR_EXPR
+            VAR (a_0)
+        VAR_EXPR
+          VAR (b_1)
+    EXPR_STMT
+      ASSIGN_EXPR
+        MEMBER_ACCESS_EXPR (mem0)
+          MEMBER_ACCESS_EXPR (nested)
+            VAR_EXPR
+              VAR (a_0)
+        MEMBER_ACCESS_EXPR (mem0)
+          VAR_EXPR
+            VAR (a_0)
+    EXPR_STMT
+      MINUS_EXPR
+        ASSIGN_EXPR
+          MEMBER_ACCESS_EXPR (mem1)
+            MEMBER_ACCESS_EXPR (nested)
+              VAR_EXPR
+                VAR (a_0)
+          PLUS_EXPR
+            MEMBER_ACCESS_EXPR (mem1)
+              MEMBER_ACCESS_EXPR (nested)
+                VAR_EXPR
+                  VAR (a_0)
+            INT_CONST (1)
+        INT_CONST (1)
+struct custom_struct0 {
+  int mem0;
+  float mem1;
+};
+struct my_type {
+  custom_struct0 nested;
+  int mem0;
+};
+void bar (void) {
+  my_type a_0;
+  custom_struct0 b_1;
+  a_0.nested = b_1;
+  (a_0.nested).mem0 = a_0.mem0;
+  ((a_0.nested).mem1 = (a_0.nested).mem1 + 1) - 1;
+}
+

--- a/samples/outputs/sample56
+++ b/samples/outputs/sample56
@@ -1,0 +1,57 @@
+FUNC_DECL
+  SCALAR_TYPE (VOID)
+  STMT_BLOCK
+    DECL_STMT
+      NAMED_TYPE (my_type)
+      VAR (var0)
+      NO_INITIALIZATION
+    DECL_STMT
+      NAMED_TYPE (custom_struct0)
+      VAR (var1)
+      NO_INITIALIZATION
+    EXPR_STMT
+      ASSIGN_EXPR
+        MEMBER_ACCESS_EXPR (nested)
+          VAR_EXPR
+            VAR (var0)
+        VAR_EXPR
+          VAR (var1)
+    EXPR_STMT
+      ASSIGN_EXPR
+        MEMBER_ACCESS_EXPR (mem0)
+          MEMBER_ACCESS_EXPR (nested)
+            VAR_EXPR
+              VAR (var0)
+        MEMBER_ACCESS_EXPR (mem0)
+          VAR_EXPR
+            VAR (var0)
+    EXPR_STMT
+      MINUS_EXPR
+        ASSIGN_EXPR
+          MEMBER_ACCESS_EXPR (mem1)
+            MEMBER_ACCESS_EXPR (nested)
+              VAR_EXPR
+                VAR (var0)
+          PLUS_EXPR
+            MEMBER_ACCESS_EXPR (mem1)
+              MEMBER_ACCESS_EXPR (nested)
+                VAR_EXPR
+                  VAR (var0)
+            INT_CONST (1)
+        INT_CONST (1)
+struct custom_struct0 {
+  int mem0;
+  float mem1;
+};
+struct my_type {
+  custom_struct0 nested;
+  int mem0;
+};
+void bar (void) {
+  my_type var0;
+  custom_struct0 var1;
+  var0.nested = var1;
+  (var0.nested).mem0 = var0.mem0;
+  ((var0.nested).mem1 = (var0.nested).mem1 + 1) - 1;
+}
+

--- a/samples/sample56.cpp
+++ b/samples/sample56.cpp
@@ -1,0 +1,44 @@
+#include "blocks/c_code_generator.h"
+#include "builder/builder.h"
+#include "builder/builder_context.h"
+#include "builder/dyn_var.h"
+#include "builder/static_var.h"
+#include <iostream>
+
+using builder::as_member;
+using builder::dyn_var;
+using builder::static_var;
+
+
+struct struct_type {
+	dyn_var<int> x;
+	dyn_var<float> y;
+};
+
+struct my_type {
+	static constexpr const char* type_name = "my_type";
+	dyn_var<struct_type> nested = builder::with_name("nested");
+	dyn_var<int> another;
+};
+
+static void bar(void) {
+	dyn_var<my_type> a;
+	dyn_var<struct_type> b;
+	
+	a.nested = b;
+	a.nested.x = a.another;
+	
+	a.nested.y++;
+}
+
+int main(int argc, char *argv[]) {
+
+	builder::builder_context context;
+	auto ast = context.extract_function_ast(bar, "bar");
+	ast->dump(std::cout, 0);
+
+	block::c_code_generator::generate_struct_decl<dyn_var<struct_type>>(std::cout);
+	block::c_code_generator::generate_struct_decl<dyn_var<my_type>>(std::cout);
+	block::c_code_generator::generate_code(ast, std::cout, 0);
+	return 0;
+}

--- a/src/builder/block_type_extractor.cpp
+++ b/src/builder/block_type_extractor.cpp
@@ -1,0 +1,5 @@
+#include "builder/block_type_extractor.h"
+
+namespace builder {
+int type_naming_counter = 0;
+}


### PR DESCRIPTION
This change further simplifies custom types in 2 ways - 
1. Custom types are no longer _required_ to inherit from builder::custom_type, although they can choose to do so for appending template args to names. Custom types are also not required to define the `type_name` member. If they don't, an automatically generated name will be assigned. This can be used in combination with c_code_generator::generate_struct_decl to create custom types. 
2. Members are no longer required to use member_of, although they can use it if members are created outside the constructor itself or if they are using specialization for dyn_var. Instead they can simply with with_name to name the members or leave the member uninitialized in which case it is assigned a generated name. This can be again used in combination with c_code_generator::generate_struct_decl to create custom types. 

Sample56 has been added to test this. Older APIs are still all supported completely.  