### PR TITLE
Fixed bug in dyn_var implementation where returns from [] and * cause bug

### DIFF
--- a/samples/outputs.var_names/sample38
+++ b/samples/outputs.var_names/sample38
@@ -51,6 +51,19 @@ STMT_BLOCK
             VAR (ptr_3)
           INT_CONST (0)
       INT_CONST (1)
+  DECL_STMT
+    NAMED_TYPE (FooT)
+    VAR (i_4)
+    SQ_BKT_EXPR
+      VAR_EXPR
+        VAR (ptr_3)
+      INT_CONST (0)
+  EXPR_STMT
+    ASSIGN_EXPR
+      MEMBER_ACCESS_EXPR (member)
+        VAR_EXPR
+          VAR (i_4)
+      INT_CONST (3)
 {
   FooT g_0;
   g_0 = g_0 + 1;
@@ -60,4 +73,6 @@ STMT_BLOCK
   FooT* ptr_3 = (&(g_0));
   ptr_3->member = 0;
   ptr_3->member = 1;
+  FooT i_4 = ptr_3[0];
+  i_4.member = 3;
 }

--- a/samples/outputs/sample38
+++ b/samples/outputs/sample38
@@ -51,6 +51,19 @@ STMT_BLOCK
             VAR (var3)
           INT_CONST (0)
       INT_CONST (1)
+  DECL_STMT
+    NAMED_TYPE (FooT)
+    VAR (var4)
+    SQ_BKT_EXPR
+      VAR_EXPR
+        VAR (var3)
+      INT_CONST (0)
+  EXPR_STMT
+    ASSIGN_EXPR
+      MEMBER_ACCESS_EXPR (member)
+        VAR_EXPR
+          VAR (var4)
+      INT_CONST (3)
 {
   FooT var0;
   var0 = var0 + 1;
@@ -60,4 +73,6 @@ STMT_BLOCK
   FooT* var3 = (&(var0));
   var3->member = 0;
   var3->member = 1;
+  FooT var4 = var3[0];
+  var4.member = 3;
 }

--- a/samples/sample38.cpp
+++ b/samples/sample38.cpp
@@ -43,6 +43,10 @@ static void bar(void) {
 	dyn_var<foo_t *> ptr = &g;
 	(*ptr).member = 0;
 	ptr->member = 1;
+
+	// This SHOULD produce a copy
+	dyn_var<foo_t> i = *ptr;
+	i.member = 3;
 }
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
A recent change (#65) simplified the implementation of pointer types esp. struct types so that the overloaded * and [] operators returned dyn_var<T> instead of builder. This allowed accessing members from these easier. However this causes a major bug where if the user writes code snippets like - 

```
dyn_var<T*> ptr;
dyn_var<T> a = ptr[i];
```

the copy a is completely removed. This is because the operators construct the returned object using (builder::cast). Due to copy elision, a itself is constructed with (cast) causing errors. If a is used multiple times, each use will have ptr[i]. Bugs arise when ptr[i] has side effects. 

This bug was discovered while implementing a toy language interpreter with @tekknolagi 

To fix this issue, we introduce a clone of dyn_var called dyn_var_mimic which is exactly like dyn_var (inherits from dyn_var), but IS NOT dyn_var. We return this type from the operator. Thus is the user directly accesses the members, the behavior is the same like before, but if a dyn_var is constructed from such an expression, copy elision doesn't happen and a copy is created. 

Minor change where dyn_var_parent_selector now strips of references from types before inheriting so dyn_var<T&> also have members. This is unrelated to above. 

Sample38 is updated to test this. 
