### PR TITLE
Added support for bool type

### DIFF
--- a/include/blocks/var.h
+++ b/include/blocks/var.h
@@ -33,7 +33,8 @@ public:
 		UNSIGNED_CHAR_TYPE,
 		VOID_TYPE,
 		FLOAT_TYPE,
-		DOUBLE_TYPE
+		DOUBLE_TYPE,
+		BOOL_TYPE
 	} scalar_type_id;
 	virtual void accept(block_visitor *a) override {
 		a->visit(self<scalar_type>());

--- a/include/builder/block_type_extractor.h
+++ b/include/builder/block_type_extractor.h
@@ -187,6 +187,15 @@ public:
 	}
 };
 
+template <>
+class type_extractor<bool> {
+public:
+	static block::type::Ptr extract_type(void) {
+		block::scalar_type::Ptr type = std::make_shared<block::scalar_type>();
+		type->scalar_type_id = block::scalar_type::BOOL_TYPE;
+		return type;
+	}
+};
 // Type specialization for pointer type
 template <typename T>
 class type_extractor<T *> {

--- a/samples/outputs.var_names/sample30
+++ b/samples/outputs.var_names/sample30
@@ -69,8 +69,12 @@ STMT_BLOCK
     VAR (o_14)
     STRING_CONST ("Hello world")
   DECL_STMT
+    SCALAR_TYPE (BOOL)
+    VAR (p_15)
+    INT_CONST (1)
+  DECL_STMT
     SCALAR_TYPE (INT)
-    VAR (x_15)
+    VAR (x_16)
     INT_CONST (0)
 {
   short int a_0;
@@ -89,5 +93,6 @@ STMT_BLOCK
   char n_13[] = "Hello world";
   n_13 = "new string";
   char const* const volatile o_14 = "Hello world";
-  int x_15 = 0;
+  bool p_15 = 1;
+  int x_16 = 0;
 }

--- a/samples/outputs/sample30
+++ b/samples/outputs/sample30
@@ -69,8 +69,12 @@ STMT_BLOCK
     VAR (var14)
     STRING_CONST ("Hello world")
   DECL_STMT
-    SCALAR_TYPE (INT)
+    SCALAR_TYPE (BOOL)
     VAR (var15)
+    INT_CONST (1)
+  DECL_STMT
+    SCALAR_TYPE (INT)
+    VAR (var16)
     INT_CONST (0)
 {
   short int var0;
@@ -89,5 +93,6 @@ STMT_BLOCK
   char var13[] = "Hello world";
   var13 = "new string";
   char const* const volatile var14 = "Hello world";
-  int var15 = 0;
+  bool var15 = 1;
+  int var16 = 0;
 }

--- a/samples/sample30.cpp
+++ b/samples/sample30.cpp
@@ -28,6 +28,8 @@ static void foo(void) {
 
 	dyn_var<const char* const volatile> o = "Hello world";
 
+	dyn_var<bool> p = true;
+
 	// bool test, fixes a bug
 	// that causes false as an init value creates a variable
 	// without context

--- a/src/blocks/c_code_generator.cpp
+++ b/src/blocks/c_code_generator.cpp
@@ -233,6 +233,9 @@ void c_code_generator::visit(scalar_type::Ptr type) {
 	case scalar_type::DOUBLE_TYPE:
 		oss << "double";
 		break;
+	case scalar_type::BOOL_TYPE:
+		oss << "bool";
+		break;
 	default:
 		assert(false && "Invalid scalar type");
 	}

--- a/src/blocks/var.cpp
+++ b/src/blocks/var.cpp
@@ -41,6 +41,8 @@ void scalar_type::dump(std::ostream &oss, int indent) {
 		oss << "FLOAT";
 	else if (scalar_type_id == DOUBLE_TYPE)
 		oss << "DOUBLE";
+	else if (scalar_type_id == BOOL_TYPE)
+		oss << "BOOL";
 	oss << ")" << std::endl;
 }
 void pointer_type::dump(std::ostream &oss, int indent) {


### PR DESCRIPTION
Basic support for new scalar type bool. Builder constructors haven't been changed, so constants of type bool should simply turn into integers. 

Sample 30 updated. 