### PR TITLE
Support out of order destruction of static_vars

### DIFF
--- a/samples/outputs.var_names/sample58
+++ b/samples/outputs.var_names/sample58
@@ -1,0 +1,74 @@
+FUNC_DECL
+  SCALAR_TYPE (VOID)
+  VAR (arg0)
+  STMT_BLOCK
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (var0)
+      VAR_EXPR
+        VAR (arg0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (y_1)
+      NO_INITIALIZATION
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (c_2)
+      VAR_EXPR
+        VAR (var0)
+    IF_STMT
+      EQUALS_EXPR
+        INT_CONST (0)
+        VAR_EXPR
+          VAR (c_2)
+      STMT_BLOCK
+        DECL_STMT
+          SCALAR_TYPE (FLOAT)
+          VAR (c_3)
+          FLOAT_CONST (2)
+      STMT_BLOCK
+        IF_STMT
+          EQUALS_EXPR
+            INT_CONST (1)
+            VAR_EXPR
+              VAR (c_2)
+          STMT_BLOCK
+            DECL_STMT
+              SCALAR_TYPE (FLOAT)
+              VAR (c_4)
+              FLOAT_CONST (3)
+          STMT_BLOCK
+            IF_STMT
+              EQUALS_EXPR
+                INT_CONST (2)
+                VAR_EXPR
+                  VAR (c_2)
+              STMT_BLOCK
+                DECL_STMT
+                  SCALAR_TYPE (FLOAT)
+                  VAR (c_5)
+                  FLOAT_CONST (5)
+              STMT_BLOCK
+                DECL_STMT
+                  SCALAR_TYPE (FLOAT)
+                  VAR (c_6)
+                  FLOAT_CONST (2)
+void bar (int arg0) {
+  int var0 = arg0;
+  int y_1;
+  int c_2 = var0;
+  if (0 == c_2) {
+    float c_3 = 2.0f;
+  } else {
+    if (1 == c_2) {
+      float c_4 = 3.0f;
+    } else {
+      if (2 == c_2) {
+        float c_5 = 5.0f;
+      } else {
+        float c_6 = 2.0f;
+      }
+    }
+  }
+}
+

--- a/samples/outputs/sample58
+++ b/samples/outputs/sample58
@@ -1,0 +1,74 @@
+FUNC_DECL
+  SCALAR_TYPE (VOID)
+  VAR (arg0)
+  STMT_BLOCK
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (var0)
+      VAR_EXPR
+        VAR (arg0)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (var1)
+      NO_INITIALIZATION
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (var2)
+      VAR_EXPR
+        VAR (var0)
+    IF_STMT
+      EQUALS_EXPR
+        INT_CONST (0)
+        VAR_EXPR
+          VAR (var2)
+      STMT_BLOCK
+        DECL_STMT
+          SCALAR_TYPE (FLOAT)
+          VAR (var3)
+          FLOAT_CONST (2)
+      STMT_BLOCK
+        IF_STMT
+          EQUALS_EXPR
+            INT_CONST (1)
+            VAR_EXPR
+              VAR (var2)
+          STMT_BLOCK
+            DECL_STMT
+              SCALAR_TYPE (FLOAT)
+              VAR (var4)
+              FLOAT_CONST (3)
+          STMT_BLOCK
+            IF_STMT
+              EQUALS_EXPR
+                INT_CONST (2)
+                VAR_EXPR
+                  VAR (var2)
+              STMT_BLOCK
+                DECL_STMT
+                  SCALAR_TYPE (FLOAT)
+                  VAR (var5)
+                  FLOAT_CONST (5)
+              STMT_BLOCK
+                DECL_STMT
+                  SCALAR_TYPE (FLOAT)
+                  VAR (var6)
+                  FLOAT_CONST (2)
+void bar (int arg0) {
+  int var0 = arg0;
+  int var1;
+  int var2 = var0;
+  if (0 == var2) {
+    float var3 = 2.0f;
+  } else {
+    if (1 == var2) {
+      float var4 = 3.0f;
+    } else {
+      if (2 == var2) {
+        float var5 = 5.0f;
+      } else {
+        float var6 = 2.0f;
+      }
+    }
+  }
+}
+

--- a/samples/sample58.cpp
+++ b/samples/sample58.cpp
@@ -1,0 +1,56 @@
+#include "blocks/c_code_generator.h"
+#include "builder/builder.h"
+#include "builder/builder_context.h"
+#include "builder/dyn_var.h"
+#include "builder/static_var.h"
+#include "builder/lib/utils.h"
+#include <iostream>
+using builder::dyn_var;
+using builder::static_var;
+
+static static_var<int> magic(dyn_var<int> x, int range) {
+	for (static_var<int> y = 0; y < range; y++) {
+		if (y == x) return y;
+	}
+	return 0;
+}
+
+
+float arr[] = {2.0, 3.0, 5.0};
+
+
+static void bar(dyn_var<int> x) {
+	/* Test out of 	order deinitialization of static variables and arrays */
+	
+	auto sv1 = new static_var<int>();
+	auto sv2 = new static_var<int>();
+
+	auto sva1 = new static_var<int[]>();
+	sva1->resize(5);
+	auto sva2 = new static_var<int[]>();
+	sva2->resize(5);
+
+
+	dyn_var<int> y;
+
+	delete sv1;
+	delete sv2;
+	delete sva1;
+	delete sva2;
+
+
+	// Test case that breaks without out of order deinitialization	
+	static_var<int> z = magic(x, 3);	
+	dyn_var<float> c = arr[z];	
+
+
+
+}
+
+int main(int argc, char *argv[]) {
+	builder::builder_context context;
+	auto ast = context.extract_function_ast(bar, "bar");
+	ast->dump(std::cout, 0);
+	block::c_code_generator::generate_code(ast, std::cout, 0);
+	return 0;
+}


### PR DESCRIPTION
This changeset relaxes the big constraint on static_vars having to be destroyed in the exact same order as they are initialized. This was previously asserted in the destructor. However this makes returning static_vars from functions difficult due to copy elision. This change relaxes this now by simply setting the size of the variable in the tracking tuple to be 0. tracking tuples of size 0 are cleaned up lazily.
This also doesn't require us to remove the element from the middle which _could_ mess with static_tag comparisons. 

Sample58 has been added to test this. 


This should also help with #76 