### PR TITLE
Fixed issue with custom_struct global constructors

### DIFF
--- a/include/builder/block_type_extractor.h
+++ b/include/builder/block_type_extractor.h
@@ -19,16 +19,20 @@ extern int type_naming_counter;
 
 template <typename T, typename V=void>
 struct type_namer {
-	static std::string obtained_name;
+	// Use a pointer to a string instead of 
+	// a string because it is possible get_type_name is called
+	// from global constructors before obtained_name is initialized
+	static std::string *obtained_name;
 	static std::string get_type_name() {
-		if (obtained_name == "") {
-			obtained_name = "custom_struct" + std::to_string(type_naming_counter++);
+		if (obtained_name == nullptr) {
+			obtained_name = new std::string();
+			*obtained_name = "custom_struct" + std::to_string(type_naming_counter++);
 		}
-		return obtained_name;
+		return *obtained_name;
 	}
 };
 template <typename T, typename V>
-std::string type_namer<T, V>::obtained_name = "";
+std::string *type_namer<T, V>::obtained_name = nullptr;
 
 template <typename T>
 struct type_namer<T, typename check_valid_type<decltype(T::type_name)>::type> {

--- a/samples/outputs.var_names/sample56
+++ b/samples/outputs.var_names/sample56
@@ -39,6 +39,12 @@ FUNC_DECL
                   VAR (a_0)
             INT_CONST (1)
         INT_CONST (1)
+    EXPR_STMT
+      ASSIGN_EXPR
+        MEMBER_ACCESS_EXPR (mem0)
+          VAR_EXPR
+            VAR (p)
+        INT_CONST (0)
 struct custom_struct0 {
   int mem0;
   float mem1;
@@ -53,5 +59,6 @@ void bar (void) {
   a_0.nested = b_1;
   (a_0.nested).mem0 = a_0.mem0;
   ((a_0.nested).mem1 = (a_0.nested).mem1 + 1) - 1;
+  p.mem0 = 0;
 }
 

--- a/samples/outputs/sample56
+++ b/samples/outputs/sample56
@@ -39,6 +39,12 @@ FUNC_DECL
                   VAR (var0)
             INT_CONST (1)
         INT_CONST (1)
+    EXPR_STMT
+      ASSIGN_EXPR
+        MEMBER_ACCESS_EXPR (mem0)
+          VAR_EXPR
+            VAR (p)
+        INT_CONST (0)
 struct custom_struct0 {
   int mem0;
   float mem1;
@@ -53,5 +59,6 @@ void bar (void) {
   var0.nested = var1;
   (var0.nested).mem0 = var0.mem0;
   ((var0.nested).mem1 = (var0.nested).mem1 + 1) - 1;
+  p.mem0 = 0;
 }
 

--- a/samples/sample56.cpp
+++ b/samples/sample56.cpp
@@ -21,6 +21,9 @@ struct my_type {
 	dyn_var<int> another;
 };
 
+
+dyn_var<struct_type> p = builder::as_global("p");
+
 static void bar(void) {
 	dyn_var<my_type> a;
 	dyn_var<struct_type> b;
@@ -29,6 +32,7 @@ static void bar(void) {
 	a.nested.x = a.another;
 	
 	a.nested.y++;
+	p.x = 0;
 }
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
There was a bug with BuildIt and unnamed custom structs with global variables. 
Unnamed structs grab their names using the type_namer trait. This trait uses a static variable to keep track of types that already have a named assigned. However, we were using std::string to hold this name. It is possible that a global constructor could request a name but the static member hasn't been initialized yet. This reads an unconstructed std::string which invokes undefined behavior. 
To fix this we make member to be a std::string* instead of std::string. 

sample56 has been updated to test this. 

