### PR TITLE
Allow custom types to specify a dereference_type for operator[]

### DIFF
--- a/include/builder/block_type_extractor.h
+++ b/include/builder/block_type_extractor.h
@@ -10,11 +10,6 @@ struct custom_type_base;
 
 
 
-template <typename T>
-struct check_valid_type {
-	typedef void type;
-};
-
 extern int type_naming_counter;
 
 template <typename T, typename V=void>

--- a/include/builder/forward_declarations.h
+++ b/include/builder/forward_declarations.h
@@ -60,6 +60,12 @@ struct with_name {
 	with_name(const std::string &n, bool wd = false) : name(n), with_decl(wd) {}
 };
 
+template <typename T>
+struct check_valid_type {
+	typedef void type;
+};
+
+
 
 } // namespace builder
 #endif

--- a/samples/outputs.var_names/sample59
+++ b/samples/outputs.var_names/sample59
@@ -1,0 +1,29 @@
+FUNC_DECL
+  SCALAR_TYPE (VOID)
+  STMT_BLOCK
+    DECL_STMT
+      NAMED_TYPE (std::vector)
+        NAMED_TYPE (std::vector)
+          SCALAR_TYPE (INT)
+      VAR (x_0)
+      NO_INITIALIZATION
+    EXPR_STMT
+      FUNCTION_CALL_EXPR
+        MEMBER_ACCESS_EXPR (resize)
+          VAR_EXPR
+            VAR (x_0)
+        INT_CONST (2)
+    EXPR_STMT
+      FUNCTION_CALL_EXPR
+        MEMBER_ACCESS_EXPR (resize)
+          SQ_BKT_EXPR
+            VAR_EXPR
+              VAR (x_0)
+            INT_CONST (1)
+        INT_CONST (1)
+void bar (void) {
+  std::vector<std::vector<int>> x_0;
+  x_0.resize(2);
+  (x_0[1]).resize(1);
+}
+

--- a/samples/outputs/sample59
+++ b/samples/outputs/sample59
@@ -1,0 +1,29 @@
+FUNC_DECL
+  SCALAR_TYPE (VOID)
+  STMT_BLOCK
+    DECL_STMT
+      NAMED_TYPE (std::vector)
+        NAMED_TYPE (std::vector)
+          SCALAR_TYPE (INT)
+      VAR (var0)
+      NO_INITIALIZATION
+    EXPR_STMT
+      FUNCTION_CALL_EXPR
+        MEMBER_ACCESS_EXPR (resize)
+          VAR_EXPR
+            VAR (var0)
+        INT_CONST (2)
+    EXPR_STMT
+      FUNCTION_CALL_EXPR
+        MEMBER_ACCESS_EXPR (resize)
+          SQ_BKT_EXPR
+            VAR_EXPR
+              VAR (var0)
+            INT_CONST (1)
+        INT_CONST (1)
+void bar (void) {
+  std::vector<std::vector<int>> var0;
+  var0.resize(2);
+  (var0[1]).resize(1);
+}
+

--- a/samples/sample59.cpp
+++ b/samples/sample59.cpp
@@ -1,0 +1,31 @@
+#include "blocks/c_code_generator.h"
+#include "builder/builder.h"
+#include "builder/builder_context.h"
+#include "builder/dyn_var.h"
+#include "builder/static_var.h"
+#include "builder/lib/utils.h"
+#include <iostream>
+using builder::dyn_var;
+using builder::static_var;
+
+
+template <typename T>
+struct vector: public builder::custom_type<T> {
+	static constexpr const char* type_name = "std::vector";
+	typedef T dereference_type;
+	dyn_var<void(int)> resize = builder::with_name("resize");
+};
+
+static void bar(void) {
+	dyn_var<vector<vector<int>>> x;
+	x.resize(2);
+	x[1].resize(1);
+}
+
+int main(int argc, char *argv[]) {
+	builder::builder_context context;
+	auto ast = context.extract_function_ast(bar, "bar");
+	ast->dump(std::cout, 0);
+	block::c_code_generator::generate_code(ast, std::cout, 0);
+	return 0;
+}


### PR DESCRIPTION
When dyn_var<> is wrapped around a custom type, the operator[] behaves like a usual type and returns generic builder. This doesn't allow accessing members from the return value (a very common requirement in custom vector implementations). 

This change allows custom types to optionally specify a `dereference_type` typedef. If defined the return type of operator[] is set accordingly and the operator returns an object of type `dyn_var_mimic<T::dereference_type>` (just like dyn_vars of pointers). 

sample59 has been added to test this. 