### PR TITLE
Fixed bug with parents_stack being static

### DIFF
--- a/.github/workflows/ci-all-samples.yml
+++ b/.github/workflows/ci-all-samples.yml
@@ -21,5 +21,5 @@ jobs:
       - run: echo "Starting tests"
       - name: Checking out repository
         uses: actions/checkout@v2
-      - run: make -C ${{ github.workspace }} -j$(nproc) run
+      - run: make -C ${{ github.workspace }} -j$(sysctl -n hw.physicalcpu) run
       - run: echo "Tests completed"

--- a/include/builder/dyn_var.h
+++ b/include/builder/dyn_var.h
@@ -64,7 +64,8 @@ struct custom_type : custom_type_base {
 	}
 };
 
-static std::vector<var *> *parents_stack = nullptr;
+extern std::vector<var *> *parents_stack;
+
 // Struct to initialize a dyn_var as member;
 struct as_member {
 	var *parent_var;

--- a/src/builder/builder.cpp
+++ b/src/builder/builder.cpp
@@ -8,6 +8,8 @@ namespace options {
 bool track_members = false;
 }
 
+std::vector<var *> *parents_stack = nullptr;
+
 template <>
 std::vector<block::type::Ptr> extract_type_vector_dyn<>(void) {
 	std::vector<block::type::Ptr> empty_vector;

--- a/src/builder/builder_context.cpp
+++ b/src/builder/builder_context.cpp
@@ -334,6 +334,11 @@ block::stmt::Ptr builder_context::extract_ast_from_function_internal(std::vector
 	current_block_stmt->static_offset.clear();
 	assert(current_block_stmt != nullptr);
 	ast = current_block_stmt;
+
+	if (parents_stack != nullptr) {
+		parents_stack->clear();
+	}
+
 	bool_vector = b;
 
 	block::stmt::Ptr ret_ast;


### PR DESCRIPTION
BuildIt had a major bug with the implementation of custom structs. BuildIt uses a parents_stack to keep track of dyn_var objects being constructed so nested objects can find existence (and pointers) of their parents. 

There was a bug where the parents_stack was declared static in the header. This would generally be okay because the stack is pushed/popped from member_begin<T> and member_end calls to which should be in the same translation unit. However since member_begin is templated there are many instances of it (potentially in different translation units) but just one member_end. This means these two could point to different instances of the stack. This leads to a problem with more pops on a vector than pushes which is undefined behavior. 

To solve this, parents_stack has been made a single global. 

Unfortunately, with the current infra, we cannot test this since it requires atleast two translation units. We can test it with a more rigorous test framework later. 

