### PR TITLE
Add basic support for generics

### DIFF
--- a/include/blocks/generic_checker.h
+++ b/include/blocks/generic_checker.h
@@ -1,0 +1,18 @@
+#ifndef BLOCKS_GENERIC_CHECKER_H
+#define BLOCKS_GENERIC_CHECKER_H
+
+#include "blocks/block_visitor.h"
+#include "blocks/var.h"
+
+namespace block {
+
+class generic_null_checker: public block_visitor {
+	using block_visitor::visit;
+
+	void visit(var::Ptr) override;
+};
+
+}
+
+
+#endif

--- a/include/blocks/var.h
+++ b/include/blocks/var.h
@@ -55,6 +55,11 @@ public:
 		np->scalar_type_id = scalar_type_id;
 		return np;
 	}
+	virtual bool is_same(block::Ptr other) override {
+		if (!isa<scalar_type>(other)) return false;
+		if (to<scalar_type>(other)->scalar_type_id != scalar_type_id) return false;
+		return true;
+	}
 };
 
 class pointer_type : public type {
@@ -70,6 +75,12 @@ public:
 		np->pointee_type = clone(pointee_type);
 		return np;
 	}
+
+	virtual bool is_same(block::Ptr other) override {
+		if (!isa<pointer_type>(other)) return false;
+		if (!to<pointer_type>(other)->pointee_type->is_same(pointee_type)) return false;
+		return true;
+	}
 };
 
 class reference_type : public type {
@@ -84,6 +95,11 @@ public:
 		auto np = clone_type(this);
 		np->referenced_type = clone(referenced_type);
 		return np;
+	}
+	virtual bool is_same(block::Ptr other) override {
+		if (!isa<reference_type>(other)) return false;
+		if (!to<reference_type>(other)->referenced_type->is_same(referenced_type)) return false;
+		return true;
 	}
 };
 
@@ -106,6 +122,16 @@ public:
 		}
 		return np;
 	}
+	virtual bool is_same(block::Ptr other) override {
+		if (!isa<function_type>(other)) return false;
+		function_type::Ptr ftype = to<function_type>(other);
+		if (!ftype->return_type->is_same(return_type)) return false;
+		if (ftype->arg_types.size() != arg_types.size()) return false;
+		for (unsigned i = 0; i < arg_types.size(); i++) {
+			if (!ftype->arg_types[i]->is_same(arg_types[i])) return false;
+		}
+		return true;
+	}
 };
 class array_type : public type {
 public:
@@ -123,6 +149,12 @@ public:
 		np->size = size;
 		return np;
 	}
+	virtual bool is_same(block::Ptr other) override {
+		if (!isa<array_type>(other)) return false;
+		if (!to<array_type>(other)->element_type->is_same(element_type)) return false;
+		if (to<array_type>(other)->size != size) return false;
+		return true;
+	}
 };
 
 // Types for complete closure
@@ -136,11 +168,18 @@ public:
 	type::Ptr closure_type;
 
 	virtual void dump(std::ostream &, int) override;
+
 	virtual block::Ptr clone_impl(void) override {
 		auto np = clone_type(this);
 		np->builder_var_type_id = builder_var_type_id;
 		np->closure_type = clone(closure_type);
 		return np;
+	}
+	virtual bool is_same(block::Ptr other) override {
+		if (!isa<builder_var_type>(other)) return false;
+		if (to<builder_var_type>(other)->builder_var_type_id != builder_var_type_id) return false;
+		if (!to<builder_var_type>(other)->closure_type->is_same(closure_type)) return false;
+		return true;
 	}
 };
 
@@ -163,7 +202,18 @@ public:
 		}
 		return np;
 	}
+	virtual bool is_same(block::Ptr other) override {
+		if (!isa<named_type>(other)) return false;
+		named_type::Ptr ntype = to<named_type>(other);
+		if (ntype->type_name != type_name) return false;
+		if (ntype->template_args.size() != template_args.size()) return false;
+		for (unsigned i = 0; i < template_args.size(); i++) {
+			if (!ntype->template_args[i]->is_same(template_args[i])) return false;
+		}
+		return true;
+	}
 };
+
 
 class var : public block {
 public:

--- a/include/builder/block_type_extractor.h
+++ b/include/builder/block_type_extractor.h
@@ -1,7 +1,9 @@
 #ifndef TYPE_EXTRACTOR_H
 #define TYPE_EXTRACTOR_H
 
+
 #include "builder/forward_declarations.h"
+#include "builder/generics.h"
 #include <algorithm>
 
 namespace builder {
@@ -305,6 +307,19 @@ public:
 		return type;
 	}
 };
+
+
+template <>
+class type_extractor<generic> {
+public:
+	static block::type::Ptr extract_type(void) {
+		// generic types don't actually have any types associated with them
+		// and would be assigned a type separately
+		return nullptr;	
+	}
+};
+
+
 
 // Extracting function types
 template <typename... args>

--- a/include/builder/generics.h
+++ b/include/builder/generics.h
@@ -1,0 +1,48 @@
+#ifndef BUILDER_GENERICS_H
+#define BUILDER_GENERICS_H
+#include "blocks/var.h"
+
+namespace builder {
+
+// TODO: Figure out if this needs to be wrapped into a generics sub namespace
+
+// Generic placeholder class to be passed inside dyn_var
+class generic {};
+
+
+// An opaque handle over block::type
+// this also allows us to overload operators and helper functions
+class type {
+public:
+	block::type::Ptr enclosed_type;
+	type(block::type::Ptr t): enclosed_type(t) {}
+
+	bool operator==(const type& other) {
+		return enclosed_type->is_same(other.enclosed_type);
+	}
+
+	bool operator!=(const type& other) {
+		return !(*this == other);
+	}
+};
+
+
+template <typename T>
+type create_type(void) {
+	return type(dyn_var<T>::create_block_type());
+}
+
+type type_of(const var& v);
+
+type array_of(const type &t, int size = -1);
+type remove_array(const type &t);
+type remove_array(const type &t, int& size);
+bool is_array(const type &t);
+
+type pointer_of(const type &t);
+bool is_pointer(const type &t);
+type remove_pointer(const type &t);
+
+}
+
+#endif

--- a/samples/outputs.var_names/sample60
+++ b/samples/outputs.var_names/sample60
@@ -1,28 +1,21 @@
 void bar (void) {
   int x_0;
-  long int y_1;
   int a_2;
   int b_3;
   float m_4;
   float n_5;
-  int var6 = b_3;
-  int var7 = a_2;
   int res_8;
-  if (var7 < var6) {
-    res_8 = var6;
+  if (a_2 < b_3) {
+    res_8 = b_3;
   } else {
-    res_8 = var7;
+    res_8 = a_2;
   }
-  int m1_9 = res_8;
-  float var10 = n_5;
-  float var11 = m_4;
   float res_12;
-  if (var11 < var10) {
-    res_12 = var10;
+  if (m_4 < n_5) {
+    res_12 = n_5;
   } else {
-    res_12 = var11;
+    res_12 = m_4;
   }
-  float m2_13 = res_12;
   int* var14 = (&(x_0));
   var14[0] = 0;
 }

--- a/samples/outputs.var_names/sample60
+++ b/samples/outputs.var_names/sample60
@@ -1,0 +1,29 @@
+void bar (void) {
+  int x_0;
+  long int y_1;
+  int a_2;
+  int b_3;
+  float m_4;
+  float n_5;
+  int var6 = b_3;
+  int var7 = a_2;
+  int res_8;
+  if (var7 < var6) {
+    res_8 = var6;
+  } else {
+    res_8 = var7;
+  }
+  int m1_9 = res_8;
+  float var10 = n_5;
+  float var11 = m_4;
+  float res_12;
+  if (var11 < var10) {
+    res_12 = var10;
+  } else {
+    res_12 = var11;
+  }
+  float m2_13 = res_12;
+  int* var14 = (&(x_0));
+  var14[0] = 0;
+}
+

--- a/samples/outputs/sample60
+++ b/samples/outputs/sample60
@@ -1,28 +1,21 @@
 void bar (void) {
   int var0;
-  long int var1;
   int var2;
   int var3;
   float var4;
   float var5;
-  int var6 = var3;
-  int var7 = var2;
   int var8;
-  if (var7 < var6) {
-    var8 = var6;
+  if (var2 < var3) {
+    var8 = var3;
   } else {
-    var8 = var7;
+    var8 = var2;
   }
-  int var9 = var8;
-  float var10 = var5;
-  float var11 = var4;
   float var12;
-  if (var11 < var10) {
-    var12 = var10;
+  if (var4 < var5) {
+    var12 = var5;
   } else {
-    var12 = var11;
+    var12 = var4;
   }
-  float var13 = var12;
   int* var14 = (&(var0));
   var14[0] = 0;
 }

--- a/samples/outputs/sample60
+++ b/samples/outputs/sample60
@@ -1,0 +1,29 @@
+void bar (void) {
+  int var0;
+  long int var1;
+  int var2;
+  int var3;
+  float var4;
+  float var5;
+  int var6 = var3;
+  int var7 = var2;
+  int var8;
+  if (var7 < var6) {
+    var8 = var6;
+  } else {
+    var8 = var7;
+  }
+  int var9 = var8;
+  float var10 = var5;
+  float var11 = var4;
+  float var12;
+  if (var11 < var10) {
+    var12 = var10;
+  } else {
+    var12 = var11;
+  }
+  float var13 = var12;
+  int* var14 = (&(var0));
+  var14[0] = 0;
+}
+

--- a/samples/sample60.cpp
+++ b/samples/sample60.cpp
@@ -1,0 +1,55 @@
+// Include the headers
+#include "blocks/c_code_generator.h"
+#include "builder/static_var.h"
+#include "builder/dyn_var.h"
+#include "blocks/rce.h"
+#include <iostream>
+
+// Include the BuildIt types
+using builder::dyn_var;
+using builder::static_var;
+using builder::generic;
+using builder::type_of;
+using builder::with_type;
+
+
+static dyn_var<generic> get_max(dyn_var<generic> x, dyn_var<generic> y) {
+
+	if (type_of(x) != type_of(y)) {
+		assert(false && "get_max can only compare similar types");
+	}
+
+	dyn_var<generic> res = with_type(type_of(x));
+	if (x < y) res = y;
+	else res = x;
+	return res;
+}
+
+static void set_zero(dyn_var<generic> ptr) {
+	*ptr = 0;
+}
+
+static void bar(void) {
+	dyn_var<generic> x;
+	x.set_type(builder::create_type<int>());
+
+	dyn_var<generic> y = with_type(builder::create_type<long>());	
+
+	dyn_var<int> a, b;
+	dyn_var<float> m,n;
+
+	dyn_var<int> m1 = get_max(with_type(a), with_type(b));
+	dyn_var<float> m2 = get_max(m, n);
+
+
+	set_zero(with_type(pointer_of(type_of(x)), &x));
+}
+
+int main(int argc, char* argv[]) {
+	builder::builder_context context;
+	auto ast = context.extract_function_ast(bar, "bar");
+	block::c_code_generator::generate_code(ast, std::cout, 0);
+	return 0;
+}
+
+

--- a/samples/sample60.cpp
+++ b/samples/sample60.cpp
@@ -47,6 +47,7 @@ static void bar(void) {
 
 int main(int argc, char* argv[]) {
 	builder::builder_context context;
+	context.run_rce = true;
 	auto ast = context.extract_function_ast(bar, "bar");
 	block::c_code_generator::generate_code(ast, std::cout, 0);
 	return 0;

--- a/src/blocks/generic_checker.cpp
+++ b/src/blocks/generic_checker.cpp
@@ -1,0 +1,11 @@
+#include "blocks/generic_checker.h"
+#include <assert.h>
+namespace block {
+
+void generic_null_checker::visit(var::Ptr v) {
+	if (v->var_type == nullptr) {
+		assert(false && "Variable has a NULL type. Check all generics that are initialized without types");
+	}
+}
+
+}

--- a/src/builder/builder_context.cpp
+++ b/src/builder/builder_context.cpp
@@ -6,6 +6,7 @@
 #include "blocks/loop_roll.h"
 #include "blocks/rce.h"
 #include "blocks/sub_expr_cleanup.h"
+#include "blocks/generic_checker.h"
 #include "blocks/var_namer.h"
 #include "builder/builder.h"
 #include "builder/dyn_var.h"
@@ -283,6 +284,11 @@ block::stmt::Ptr builder_context::extract_ast_from_function_impl(void) {
 
 	// Before making any changes, untangle the whole AST
 	ast = clone(ast);
+	
+	// Make sure any generics haven't been left 
+	// unspecialized
+	block::generic_null_checker checker;
+	ast->accept(&checker);
 
 	block::var_namer::name_vars(ast);
 

--- a/src/builder/generics.cpp
+++ b/src/builder/generics.cpp
@@ -1,0 +1,44 @@
+#include "builder/dyn_var.h"
+#include "blocks/var.h"
+
+namespace builder {
+
+type type_of(const var& v) {
+	assert(v.block_var);
+	// We want to avoid cloning variables that themselves don't have a type yet
+	assert(v.block_var->var_type && "Cloning type from variable that doesn't have a type");
+	return type(v.block_var->var_type);
+}
+
+type array_of(const type &t, int size) {
+	block::array_type::Ptr at = std::make_shared<block::array_type>();
+	at->element_type = t.enclosed_type;
+	at->size = size;
+	return type(at);
+}
+
+bool is_array(const type &t) {
+	return block::isa<block::array_type>(t.enclosed_type);
+}
+type remove_array(const type &t) {
+	return type(block::to<block::array_type>(t.enclosed_type)->element_type);
+}
+type remove_array(const type &t, int &size) {
+	size = block::to<block::array_type>(t.enclosed_type)->size;
+	return type(block::to<block::array_type>(t.enclosed_type)->element_type);
+}
+
+type pointer_of(const type &t) {
+	block::pointer_type::Ptr pt = std::make_shared<block::pointer_type>();
+	pt->pointee_type = t.enclosed_type;
+	return type(pt);
+}
+bool is_pointer(const type& t) {
+	return block::isa<block::pointer_type>(t.enclosed_type);
+}
+type remove_pointer(const type &t) {
+	return type(block::to<block::pointer_type>(t.enclosed_type)->pointee_type);
+}
+
+
+}


### PR DESCRIPTION
This change set introduces the dyn_var<generic> type. This type doesn't have type when created but can be assigned one through the execution of first stage logic. This allows writing generic code that generates code with different types. This also allows computing array and template sizes through first stage code. 

The new builder::type opaque type has been introduced that holds runtime type values. These type provides helper functions to operate on types like pointer_of, array_of etc. 

Sample 60 has been added to test this basic change. 