### PR TITLE
Add support for nd_vars and Merge pattern matchers

### DIFF
--- a/include/blocks/block_replacer.h
+++ b/include/blocks/block_replacer.h
@@ -8,6 +8,11 @@ class block_replacer : public block_visitor {
 public:
 	using block_visitor::visit;
 	std::shared_ptr<block> node;
+
+	// optional generic exact replacing mechanism
+	std::shared_ptr<block> to_replace;
+	std::shared_ptr<block> replace_with;
+
 	template <typename T = expr>
 	typename T::Ptr rewrite(typename T::Ptr ptr) {
 		auto tmp = node;
@@ -15,6 +20,8 @@ public:
 		ptr->accept(this);
 		auto ret = to<T>(node);
 		node = tmp;
+		if (to_replace != nullptr && ret == to_replace)
+			return to<T>(replace_with);
 		return ret;
 	}
 	void unary_helper(std::shared_ptr<unary_expr> a);

--- a/include/blocks/expr.h
+++ b/include/blocks/expr.h
@@ -729,10 +729,8 @@ public:
 	}
 };
 
-class addr_of_expr : public expr {
-public:
-	expr::Ptr expr1;
-
+class addr_of_expr: public unary_expr {
+public:	
 	typedef std::shared_ptr<addr_of_expr> Ptr;
 	virtual void dump(std::ostream &oss, int) override;
 	virtual void accept(block_visitor *a) override {

--- a/include/blocks/matchers/matchers.h
+++ b/include/blocks/matchers/matchers.h
@@ -1,0 +1,22 @@
+#ifndef BLOCKS_MATCHERS_H
+#define BLOCKS_MATCHERS_H
+#include "blocks/matchers/patterns.h"
+#include "blocks/block.h"
+#include <map>
+
+namespace block {
+namespace matcher {
+
+struct match {
+	block::Ptr node;
+	std::map<std::string, block::Ptr> captures;
+};
+
+std::vector<match> find_all_matches(std::shared_ptr<pattern> p, block::Ptr node);
+bool check_match(std::shared_ptr<pattern> p, block::Ptr node, std::map<std::string, block::Ptr>& captures);
+
+}
+}
+
+
+#endif

--- a/include/blocks/matchers/patterns.h
+++ b/include/blocks/matchers/patterns.h
@@ -1,0 +1,448 @@
+#ifndef BLOCKS_PATTERN_MATCHER_H
+#define BLOCKS_PATTERN_MATCHER_H
+#include <memory>
+#include <string>
+#include <vector>
+namespace block {
+namespace matcher {
+
+struct pattern: public std::enable_shared_from_this<pattern> {
+	typedef std::shared_ptr<pattern> Ptr;
+	enum class node_type {
+		block,
+		expr,
+		unary_expr,
+		binary_expr,
+		not_expr,
+		unary_minus_expr,
+		bitwise_not_expr,
+		and_expr,
+		bitwise_and_expr,
+		or_expr,
+		bitwise_or_expr,
+		bitwise_xor_expr,
+		plus_expr,
+		minus_expr,
+		mul_expr,
+		div_expr,
+		lt_expr,
+		gt_expr,
+		lte_expr,
+		gte_expr,
+		lshift_expr,
+		rshift_expr,
+		equals_expr,
+		ne_expr,
+		mod_expr,
+		var_expr,
+		const_expr,
+		int_const,
+		double_const,
+		float_const,
+		string_const,
+		assign_expr,
+		stmt,
+		expr_stmt,
+		stmt_block,
+		decl_stmt,
+		if_stmt,
+		label,
+		label_stmt,
+		goto_stmt,
+		while_stmt,
+		for_stmt,
+		break_stmt,
+		continue_stmt,
+		sq_bkt_expr,
+		function_call_expr,
+		initializer_list_expr,
+		foreign_expr_base,
+		member_access_expr,
+		addr_of_expr,
+		var,
+		// types will probably be never used in matching, but we will keep them
+		type,
+		scalar_type,
+		pointer_type,
+		function_type,
+		array_type,
+		builder_var_type,
+		named_type,
+
+		func_decl,
+		return_stmt
+	};
+	node_type type;
+	std::string name;
+	std::vector<pattern::Ptr> children;
+	// Extra fields that can be supplied to be matched
+	bool has_const = false;
+	double const_val_double = 0;
+	int const_val_int = 0;
+	std::string const_val_string = "";
+	
+	// Constructor that assigns a name
+
+	pattern(node_type t, std::string _name, std::vector<pattern::Ptr> _children)
+		: type (t), name(_name), children(_children) {}
+	pattern(node_type t, std::string _name): type(t), name(_name), children({}) {}
+
+};
+// The helper functions to create nodes
+static inline pattern::Ptr block(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::block, name);
+}
+static inline pattern::Ptr expr(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::expr, name);
+}
+static inline pattern::Ptr unary_expr(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::unary_expr, name);
+}
+static inline pattern::Ptr unary_expr(pattern::Ptr x, std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::unary_expr, name, std::vector<pattern::Ptr>({x}));
+}
+static inline pattern::Ptr binary_expr(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::binary_expr, name);
+}
+static inline pattern::Ptr binary_expr(pattern::Ptr x, pattern::Ptr y, std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::binary_expr, name, std::vector<pattern::Ptr>({x, y}));
+}
+static inline pattern::Ptr not_expr(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::not_expr, name);
+}
+static inline pattern::Ptr not_expr(pattern::Ptr x, std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::not_expr, name, std::vector<pattern::Ptr>({x}));
+}
+static inline pattern::Ptr operator! (pattern::Ptr x) {
+	return not_expr(x);
+}
+static inline pattern::Ptr and_expr(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::and_expr, name);
+}
+static inline pattern::Ptr or_expr(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::or_expr, name);
+}
+static inline pattern::Ptr plus_expr(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::plus_expr, name);
+}
+static inline pattern::Ptr minus_expr(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::minus_expr, name);
+}
+static inline pattern::Ptr mul_expr(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::mul_expr, name);
+}
+static inline pattern::Ptr div_expr(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::div_expr, name);
+}
+static inline pattern::Ptr lt_expr(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::lt_expr, name);
+}
+static inline pattern::Ptr gt_expr(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::gt_expr, name);
+}
+static inline pattern::Ptr lte_expr(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::lte_expr, name);
+}
+static inline pattern::Ptr gte_expr(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::gte_expr, name);
+}
+static inline pattern::Ptr equals_expr(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::equals_expr, name);
+}
+static inline pattern::Ptr ne_expr(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::ne_expr, name);
+}
+static inline pattern::Ptr mod_expr(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::mod_expr, name);
+}
+static inline pattern::Ptr and_expr(pattern::Ptr x, pattern::Ptr y, std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::and_expr, name, std::vector<pattern::Ptr>({x, y}));
+}
+static inline pattern::Ptr operator && (pattern::Ptr x, pattern::Ptr y) {
+	return and_expr(x, y);
+}
+static inline pattern::Ptr or_expr(pattern::Ptr x, pattern::Ptr y, std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::or_expr, name, std::vector<pattern::Ptr>({x, y}));
+}
+static inline pattern::Ptr operator || (pattern::Ptr x, pattern::Ptr y) {
+	return or_expr(x, y);
+}
+static inline pattern::Ptr plus_expr(pattern::Ptr x, pattern::Ptr y, std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::plus_expr, name, std::vector<pattern::Ptr>({x, y}));
+}
+static inline pattern::Ptr operator+(pattern::Ptr x, pattern::Ptr y) {
+	return plus_expr(x, y);
+}
+static inline pattern::Ptr minus_expr(pattern::Ptr x, pattern::Ptr y, std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::minus_expr, name, std::vector<pattern::Ptr>({x, y}));
+}
+static inline pattern::Ptr operator-(pattern::Ptr x, pattern::Ptr y) {
+	return minus_expr(x, y);
+}
+static inline pattern::Ptr mul_expr(pattern::Ptr x, pattern::Ptr y, std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::mul_expr, name, std::vector<pattern::Ptr>({x, y}));
+}
+static inline pattern::Ptr operator*(pattern::Ptr x, pattern::Ptr y) {
+	return mul_expr(x, y);
+}
+static inline pattern::Ptr div_expr(pattern::Ptr x, pattern::Ptr y, std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::div_expr, name, std::vector<pattern::Ptr>({x, y}));
+}
+static inline pattern::Ptr operator/ (pattern::Ptr x, pattern::Ptr y) {
+	return div_expr(x, y);
+}
+static inline pattern::Ptr lt_expr(pattern::Ptr x, pattern::Ptr y, std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::lt_expr, name, std::vector<pattern::Ptr>({x, y}));
+}
+static inline pattern::Ptr operator < (pattern::Ptr x, pattern::Ptr y) {
+	return lt_expr(x, y);
+}
+static inline pattern::Ptr gt_expr(pattern::Ptr x, pattern::Ptr y, std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::gt_expr, name, std::vector<pattern::Ptr>({x, y}));
+}
+static inline pattern::Ptr operator > (pattern::Ptr x, pattern::Ptr y) {
+	return gt_expr(x, y);
+}
+static inline pattern::Ptr lte_expr(pattern::Ptr x, pattern::Ptr y, std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::lte_expr, name, std::vector<pattern::Ptr>({x, y}));
+}
+static inline pattern::Ptr operator <= (pattern::Ptr x, pattern::Ptr y) {
+	return lte_expr(x, y);
+}
+static inline pattern::Ptr gte_expr(pattern::Ptr x, pattern::Ptr y, std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::gte_expr, name, std::vector<pattern::Ptr>({x, y}));
+}
+static inline pattern::Ptr operator >= (pattern::Ptr x, pattern::Ptr y) {
+	return gte_expr(x, y);
+}
+static inline pattern::Ptr equals_expr(pattern::Ptr x, pattern::Ptr y, std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::equals_expr, name, std::vector<pattern::Ptr>({x, y}));
+}
+static inline pattern::Ptr operator == (pattern::Ptr x, pattern::Ptr y) {
+	return equals_expr(x, y);
+}
+static inline pattern::Ptr ne_expr(pattern::Ptr x, pattern::Ptr y, std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::ne_expr, name, std::vector<pattern::Ptr>({x, y}));
+}
+static inline pattern::Ptr operator != (pattern::Ptr x, pattern::Ptr y) {
+	return ne_expr(x, y);
+}
+static inline pattern::Ptr mod_expr(pattern::Ptr x, pattern::Ptr y, std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::mod_expr, name, std::vector<pattern::Ptr>({x, y}));
+}
+static inline pattern::Ptr operator % (pattern::Ptr x, pattern::Ptr y) {
+	return mod_expr(x, y);
+}
+static inline pattern::Ptr assign_expr(pattern::Ptr x, pattern::Ptr y, std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::assign_expr, name, std::vector<pattern::Ptr>({x, y}));
+}
+static inline pattern::Ptr sq_bkt_expr(pattern::Ptr x, pattern::Ptr y, std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::sq_bkt_expr, name, std::vector<pattern::Ptr>({x, y}));
+}
+static inline pattern::Ptr var_expr(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::var_expr, name);
+}
+static inline pattern::Ptr const_expr(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::const_expr, name);
+}
+
+// Lets not mess with overloads on constants because they can mess with pointer arithmetic
+static inline pattern::Ptr int_const(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::int_const, name);
+}
+static inline pattern::Ptr int_const(const int val, std::string name = "") {
+	auto p = std::make_shared<pattern>(pattern::node_type::int_const, name);
+	p->has_const = true;
+	p->const_val_int = val;
+	return p;
+}
+static inline pattern::Ptr double_const(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::double_const, name);
+}
+static inline pattern::Ptr double_const(const double val, std::string name = "") {
+	auto p = std::make_shared<pattern>(pattern::node_type::double_const, name);
+	p->has_const = true;
+	p->const_val_double = val;
+	return p;
+}
+static inline pattern::Ptr float_const(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::float_const, name);
+}
+static inline pattern::Ptr float_const(const double val, std::string name = "") {
+	auto p = std::make_shared<pattern>(pattern::node_type::float_const, name);
+	p->has_const = true;
+	p->const_val_double = val;
+	return p;
+}
+static inline pattern::Ptr string_const(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::string_const, name);
+}
+// string_const constructor needs a special name so that the value doesn't mix up with names
+static inline pattern::Ptr string_const_with_val(std::string val, std::string name = "") {
+	auto p = std::make_shared<pattern>(pattern::node_type::string_const, name);
+	p->has_const = true;
+	p->const_val_string = val;
+	return p;
+}
+static inline pattern::Ptr assign_expr(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::assign_expr, name);
+}
+
+static inline pattern::Ptr unary_minus_expr(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::unary_minus_expr, name);
+}
+static inline pattern::Ptr unary_minus_expr(pattern::Ptr x, std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::unary_minus_expr, name, std::vector<pattern::Ptr>({x}));
+}
+static inline pattern::Ptr operator-(pattern::Ptr x) {
+	return unary_minus_expr(x);
+}
+static inline pattern::Ptr bitwise_not_expr(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::bitwise_not_expr, name);
+}
+static inline pattern::Ptr bitwise_not_expr(pattern::Ptr x, std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::bitwise_not_expr, name, std::vector<pattern::Ptr>({x}));
+}
+static inline pattern::Ptr operator~(pattern::Ptr x) {
+	return bitwise_not_expr(x);
+}
+static inline pattern::Ptr bitwise_and_expr(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::bitwise_and_expr, name);
+}
+static inline pattern::Ptr bitwise_and_expr(pattern::Ptr x, pattern::Ptr y, std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::bitwise_and_expr, name, std::vector<pattern::Ptr>({x, y}));
+}
+static inline pattern::Ptr operator & (pattern::Ptr x, pattern::Ptr y) {
+	return bitwise_and_expr(x, y);
+}
+static inline pattern::Ptr bitwise_or_expr(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::bitwise_or_expr, name);
+}
+static inline pattern::Ptr bitwise_or_expr(pattern::Ptr x, pattern::Ptr y, std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::bitwise_or_expr, name, std::vector<pattern::Ptr>({x, y}));
+}
+static inline pattern::Ptr operator | (pattern::Ptr x, pattern::Ptr y) {
+	return bitwise_or_expr(x, y);
+}
+static inline pattern::Ptr bitwise_xor_expr(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::bitwise_xor_expr, name);
+}
+static inline pattern::Ptr bitwise_xor_expr(pattern::Ptr x, pattern::Ptr y, std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::bitwise_xor_expr, name, std::vector<pattern::Ptr>({x, y}));
+}
+static inline pattern::Ptr operator ^ (pattern::Ptr x, pattern::Ptr y) {
+	return bitwise_xor_expr(x, y);
+}
+static inline pattern::Ptr lshift_expr(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::lshift_expr, name);
+}
+static inline pattern::Ptr lshift_expr(pattern::Ptr x, pattern::Ptr y, std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::lshift_expr, name, std::vector<pattern::Ptr>({x, y}));
+}
+static inline pattern::Ptr operator << (pattern::Ptr x, pattern::Ptr y) {
+	return lshift_expr(x, y);
+}
+static inline pattern::Ptr rshift_expr(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::rshift_expr, name);
+}
+static inline pattern::Ptr rshift_expr(pattern::Ptr x, pattern::Ptr y, std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::rshift_expr, name, std::vector<pattern::Ptr>({x, y}));
+}
+static inline pattern::Ptr operator >> (pattern::Ptr x, pattern::Ptr y) {
+	return rshift_expr(x, y);
+}
+
+static inline pattern::Ptr stmt(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::stmt, name);
+}
+static inline pattern::Ptr expr_stmt(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::expr_stmt, name);
+}
+static inline pattern::Ptr stmt_block(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::stmt_block, name);
+}
+static inline pattern::Ptr decl_stmt(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::decl_stmt, name);
+}
+static inline pattern::Ptr if_stmt(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::if_stmt, name);
+}
+static inline pattern::Ptr label(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::label, name);
+}
+static inline pattern::Ptr label_stmt(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::label_stmt, name);
+}
+static inline pattern::Ptr goto_stmt(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::goto_stmt, name);
+}
+static inline pattern::Ptr while_stmt(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::while_stmt, name);
+}
+static inline pattern::Ptr for_stmt(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::for_stmt, name);
+}
+static inline pattern::Ptr break_stmt(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::break_stmt, name);
+}
+static inline pattern::Ptr continue_stmt(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::continue_stmt, name);
+}
+static inline pattern::Ptr sq_bkt_expr(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::sq_bkt_expr, name);
+}
+static inline pattern::Ptr function_call_expr(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::function_call_expr, name);
+}
+static inline pattern::Ptr initializer_list_expr(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::initializer_list_expr, name);
+}
+static inline pattern::Ptr foreign_expr_base(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::foreign_expr_base, name);
+}
+static inline pattern::Ptr member_access_expr(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::member_access_expr, name);
+}
+static inline pattern::Ptr addr_of_expr(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::addr_of_expr, name);
+}
+static inline pattern::Ptr addr_of_expr(pattern::Ptr x, std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::addr_of_expr, name, std::vector<pattern::Ptr>({x}));
+}
+static inline pattern::Ptr var(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::var, name);
+}
+static inline pattern::Ptr type(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::type, name);
+}
+static inline pattern::Ptr scalar_type(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::scalar_type, name);
+}
+static inline pattern::Ptr pointer_type(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::pointer_type, name);
+}
+static inline pattern::Ptr function_type(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::function_type, name);
+}
+static inline pattern::Ptr array_type(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::array_type, name);
+}
+static inline pattern::Ptr builder_var_type(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::builder_var_type, name);
+}
+static inline pattern::Ptr named_type(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::named_type, name);
+}
+static inline pattern::Ptr func_decl(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::func_decl, name);
+}
+static inline pattern::Ptr return_stmt(std::string name = "") {
+	return std::make_shared<pattern>(pattern::node_type::return_stmt, name);
+}
+
+
+
+} // namespace matchers
+} // namespace block
+
+#endif

--- a/include/blocks/matchers/replacers.h
+++ b/include/blocks/matchers/replacers.h
@@ -1,0 +1,17 @@
+#ifndef BLOCK_REPLACERS_H
+#define BLOCK_REPLACERS_H
+
+#include "blocks/matchers/matchers.h"
+#include "blocks/block.h"
+#include "blocks/stmt.h"
+#include "blocks/expr.h"
+#include "blocks/var.h"
+
+namespace block {
+namespace matcher {
+
+void replace_match(block::Ptr, match, pattern::Ptr);
+
+}
+}
+#endif

--- a/include/builder/exceptions.h
+++ b/include/builder/exceptions.h
@@ -21,6 +21,11 @@ struct MemoizationException : public std::exception {
 	block::stmt_block::Ptr parent;
 	int32_t child_id;
 };
+
+struct NonDeterministicFailureException: public std::exception {
+	NonDeterministicFailureException() {}
+};
+
 } // namespace builder
 
 #endif

--- a/include/builder/forward_declarations.h
+++ b/include/builder/forward_declarations.h
@@ -65,7 +65,8 @@ struct check_valid_type {
 	typedef void type;
 };
 
-
+// Generator states for non-deterministic values
+struct nd_var_gen_base;
 
 } // namespace builder
 #endif

--- a/include/builder/nd_var.h
+++ b/include/builder/nd_var.h
@@ -1,0 +1,92 @@
+#ifndef ND_VAR_H
+#define ND_VAR_H
+
+#include "builder/builder.h"
+#include "builder/static_var.h"
+#include "util/tracer.h"
+#include "builder/exceptions.h"
+
+namespace builder {
+
+template <typename T> 
+struct nd_var {
+};
+
+struct nd_var_gen_base {
+};
+
+template <typename T>
+struct nd_var_gen: public nd_var_gen_base {
+};
+
+template <>
+struct nd_var_gen<bool>: public nd_var_gen_base {
+				// false, // true	
+	bool allowed_values[2] = {true, true};
+};
+
+
+template <typename T>
+std::shared_ptr<nd_var_gen<T>> get_or_create_generator(tracer::tag req_tag) {
+	std::string tag_name = req_tag.stringify();
+
+	if (builder_context::current_builder_context->nd_state_map->find(tag_name) ==
+		builder_context::current_builder_context->nd_state_map->end()) {
+		(*(builder_context::current_builder_context->nd_state_map))[tag_name] = std::make_shared<nd_var_gen<T>>();
+	}
+
+	return std::static_pointer_cast<nd_var_gen<T>>(
+		(*(builder_context::current_builder_context->nd_state_map))[tag_name]);
+}
+
+/* contstraints on bool types
+Bool types are enumerable so it is suitable for nd_var
+Since bool has only two values we don't need too many constraints. 
+The only valid constraint is requires_equal. 
+
+The lattice for bools also has just two points, 
+the order can be specified by initial preferred value
+*/
+
+template <>
+struct nd_var<bool> {
+
+	static_var<int> current_value;
+	tracer::tag current_tag;
+
+	// Values can only be retrieved
+	operator bool () const {
+		return current_value;
+	}
+
+	void sample(bool default_value = false) {
+		current_tag = get_offset_in_function();			
+		auto generator = get_or_create_generator<bool>(current_tag);
+
+		if (generator->allowed_values[default_value] == true)
+			current_value = default_value;
+		else if (generator->allowed_values[!default_value] == true)
+			current_value = !default_value;
+		else 
+			assert(false && "nd bool has no possible values allowed");
+	}
+
+	nd_var(bool default_value = false) {
+		sample(default_value);
+	}
+	
+	void require_equal(bool value) {
+		if (value == current_value) return;
+		// We have sampled a wrong value, time to update 
+		// the generator and reset
+
+		auto generator = get_or_create_generator<bool>(current_tag);
+		generator->allowed_values[current_value] = false;
+	
+		throw NonDeterministicFailureException();
+	}
+};
+
+
+}
+#endif

--- a/include/builder/static_var.h
+++ b/include/builder/static_var.h
@@ -101,6 +101,9 @@ public:
 		assert(builder_context::current_builder_context != nullptr);
 		// Deferred static variables are kept separate because they are never untracked
 		// in the destructor
+		// Even though the usual static vars can be destroyed out of order, these might create
+		// unncessary bubbles in the queue
+		// TODO: Consider merging these two
 		builder_context::current_builder_context->deferred_static_var_tuples.push_back(
 		    tracking_tuple((unsigned char *)&val, sizeof(T), this));
 		try_get_name();

--- a/make/dirs.mk
+++ b/make/dirs.mk
@@ -9,6 +9,7 @@ DEPS_DIR=$(BASE_DIR)/deps
 SAMPLES_SRCS=$(wildcard $(SAMPLES_DIR)/*.cpp)
 SAMPLES=$(subst $(SAMPLES_DIR),$(BUILD_DIR),$(SAMPLES_SRCS:.cpp=))
 INCLUDES=$(wildcard $(INCLUDE_DIR)/*.h) $(wildcard $(INCLUDE_DIR)/*/*.h) $(BUILD_DIR)/gen_headers/gen/compiler_headers.h
+INCLUDES+=$(wildcard $(INCLUDE_DIR)/*/*/*.h)
 
 BUILDER_SRC=$(wildcard $(SRC_DIR)/builder/*.cpp)
 BLOCKS_SRC=$(wildcard $(SRC_DIR)/blocks/*.cpp)

--- a/samples/outputs.var_names/sample61
+++ b/samples/outputs.var_names/sample61
@@ -1,0 +1,5 @@
+void bar (void) {
+  int x_0 = 1;
+  int y_1 = 0;
+}
+

--- a/samples/outputs.var_names/sample62
+++ b/samples/outputs.var_names/sample62
@@ -1,0 +1,73 @@
+Found 1 matches
+-----
+ASSIGN_EXPR
+  VAR_EXPR
+    VAR (x_0)
+  PLUS_EXPR
+    VAR_EXPR
+      VAR (x_0)
+    INT_CONST (1)
+-----
+Found 1 matches
+-----
+PLUS_EXPR
+  VAR_EXPR
+    VAR (x_0)
+  INT_CONST (0)
+-----
+After all replacements
+FUNC_DECL
+  SCALAR_TYPE (VOID)
+  STMT_BLOCK
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (x_0)
+      INT_CONST (0)
+    EXPR_STMT
+      ASSIGN_EXPR
+        VAR_EXPR
+          VAR (x_0)
+        PLUS_EXPR
+          VAR_EXPR
+            VAR (x_0)
+          INT_CONST (1)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (y_1)
+      INT_CONST (0)
+    EXPR_STMT
+      ASSIGN_EXPR
+        VAR_EXPR
+          VAR (y_1)
+        PLUS_EXPR
+          VAR_EXPR
+            VAR (x_0)
+          INT_CONST (1)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (z_2)
+      INT_CONST (0)
+    EXPR_STMT
+      ASSIGN_EXPR
+        VAR_EXPR
+          VAR (z_2)
+        PLUS_EXPR
+          VAR_EXPR
+            VAR (z_2)
+          INT_CONST (2)
+    EXPR_STMT
+      ASSIGN_EXPR
+        VAR_EXPR
+          VAR (z_2)
+        VAR_EXPR
+          VAR (x_0)
+void foo (void) {
+  int x_0 = 0;
+  x_0 = x_0 + 1;
+  int y_1 = 0;
+  y_1 = x_0 + 1;
+  int z_2 = 0;
+  z_2 = z_2 + 2;
+  z_2 = x_0;
+}
+

--- a/samples/outputs/sample61
+++ b/samples/outputs/sample61
@@ -1,0 +1,5 @@
+void bar (void) {
+  int var0 = 1;
+  int var1 = 0;
+}
+

--- a/samples/outputs/sample62
+++ b/samples/outputs/sample62
@@ -1,0 +1,73 @@
+Found 1 matches
+-----
+ASSIGN_EXPR
+  VAR_EXPR
+    VAR (var0)
+  PLUS_EXPR
+    VAR_EXPR
+      VAR (var0)
+    INT_CONST (1)
+-----
+Found 1 matches
+-----
+PLUS_EXPR
+  VAR_EXPR
+    VAR (var0)
+  INT_CONST (0)
+-----
+After all replacements
+FUNC_DECL
+  SCALAR_TYPE (VOID)
+  STMT_BLOCK
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (var0)
+      INT_CONST (0)
+    EXPR_STMT
+      ASSIGN_EXPR
+        VAR_EXPR
+          VAR (var0)
+        PLUS_EXPR
+          VAR_EXPR
+            VAR (var0)
+          INT_CONST (1)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (var1)
+      INT_CONST (0)
+    EXPR_STMT
+      ASSIGN_EXPR
+        VAR_EXPR
+          VAR (var1)
+        PLUS_EXPR
+          VAR_EXPR
+            VAR (var0)
+          INT_CONST (1)
+    DECL_STMT
+      SCALAR_TYPE (INT)
+      VAR (var2)
+      INT_CONST (0)
+    EXPR_STMT
+      ASSIGN_EXPR
+        VAR_EXPR
+          VAR (var2)
+        PLUS_EXPR
+          VAR_EXPR
+            VAR (var2)
+          INT_CONST (2)
+    EXPR_STMT
+      ASSIGN_EXPR
+        VAR_EXPR
+          VAR (var2)
+        VAR_EXPR
+          VAR (var0)
+void foo (void) {
+  int var0 = 0;
+  var0 = var0 + 1;
+  int var1 = 0;
+  var1 = var0 + 1;
+  int var2 = 0;
+  var2 = var2 + 2;
+  var2 = var0;
+}
+

--- a/samples/sample61.cpp
+++ b/samples/sample61.cpp
@@ -1,0 +1,33 @@
+// Include the headers
+#include "blocks/c_code_generator.h"
+#include "builder/static_var.h"
+#include "builder/dyn_var.h"
+#include "blocks/rce.h"
+#include "builder/nd_var.h"
+#include <iostream>
+
+// Include the BuildIt types
+using builder::dyn_var;
+using builder::static_var;
+using builder::nd_var;
+
+
+static void bar(void) {
+	nd_var<bool> t;
+	dyn_var<int> x = (bool)t;
+	t.require_equal(true);
+
+	nd_var<bool> r(true);
+	dyn_var<int> y = (bool)r;
+	r.require_equal(false);
+	t.require_equal(true);
+}
+
+int main(int argc, char* argv[]) {
+	builder::builder_context context;
+	auto ast = context.extract_function_ast(bar, "bar");
+	block::c_code_generator::generate_code(ast, std::cout, 0);
+	return 0;
+}
+
+

--- a/samples/sample62.cpp
+++ b/samples/sample62.cpp
@@ -1,0 +1,58 @@
+#include "blocks/matchers/patterns.h"
+#include "blocks/matchers/matchers.h"
+#include "blocks/matchers/replacers.h"
+#include "builder/builder_context.h"
+#include "builder/dyn_var.h"
+#include "builder/static_var.h"
+#include "blocks/c_code_generator.h"
+
+using namespace block::matcher;
+using builder::dyn_var;
+using builder::static_var;
+
+static void foo(void) {
+	dyn_var<int> x = 0;	
+	x = x + 1;
+	// this should not be matched
+	dyn_var<int> y = 0;
+	y = x + 1;
+	dyn_var<int> z = 0;
+	z = z + 2;
+
+
+	z = x + 0;
+}
+
+int main(int argc, char* argv[]) {
+	builder::builder_context context;
+	auto ast = context.extract_function_ast(foo, "foo");
+
+	auto p = assign_expr(var("a"), binary_expr(var("a"), int_const(1)));
+	auto matches = find_all_matches(p, ast);
+	std::cout << "Found " << matches.size() << " matches" << std::endl;
+	std::cout << "-----" << std::endl;
+	for (auto x: matches) {
+		x.node->dump(std::cout, 0);
+		std::cout << "-----" << std::endl;
+	}
+
+
+	auto p2 = expr("a") + int_const(0);
+	auto matches2 = find_all_matches(p2, ast);
+	std::cout << "Found " << matches2.size() << " matches" << std::endl;
+	std::cout << "-----" << std::endl;
+	for (auto x: matches2) {
+		x.node->dump(std::cout, 0);
+		std::cout << "-----" << std::endl;
+	}
+	
+	auto p3 = expr("a");
+
+	for (auto x: matches2) {
+		replace_match(ast, x, p3);
+	}	
+	std::cout << "After all replacements" << std::endl;
+	ast->dump(std::cout, 0);
+	block::c_code_generator::generate_code(ast, std::cout, 0);
+	return 0;
+}	

--- a/src/blocks/matchers.cpp
+++ b/src/blocks/matchers.cpp
@@ -1,0 +1,455 @@
+#include "blocks/matchers/matchers.h"
+#include "blocks/block.h"
+#include "blocks/stmt.h"
+#include "blocks/expr.h"
+#include "blocks/var.h"
+#include <memory>
+#include <map>
+#include <iostream>
+namespace block {
+namespace matcher {
+
+static bool pattern_error(bool error, std::string message) {
+	if (!error) {
+		std::cerr << "PM error: " << message << std::endl;
+		return false;
+	}
+	return true;
+}
+#define PATTERN_ASSERT(expr, message) if (!pattern_error(expr, message)) return false
+
+template <typename T>
+static bool check_unary(std::shared_ptr<pattern> p, block::Ptr node, std::map<std::string, block::Ptr>& captures) {
+	if (!isa<T>(node)) return false;
+	if (p->children.size() > 0) {
+		block::Ptr child = to<::block::unary_expr>(node)->expr1;
+		if (!check_match(p->children[0], child, captures))
+			return false;
+	}
+	return true;
+}
+template <typename T>
+static bool check_binary(std::shared_ptr<pattern> p, block::Ptr node, std::map<std::string, block::Ptr>& captures) {
+	if (!isa<T>(node)) return false;
+	if (p->children.size() > 0) {
+		block::Ptr child1 = to<::block::binary_expr>(node)->expr1;
+		block::Ptr child2 = to<::block::binary_expr>(node)->expr2;
+		if (!check_match(p->children[0], child1, captures)) return false;
+		if (!check_match(p->children[1], child2, captures)) return false;
+	}
+	return true;
+}
+bool check_match(std::shared_ptr<pattern> p, block::Ptr node, std::map<std::string, block::Ptr>& captures) {
+	switch (p->type) {
+		case pattern::node_type::block:
+			// Every node is a block, nothing to check		
+			break;
+		case pattern::node_type::expr:
+			if (!isa<::block::expr>(node)) return false; 
+			break;
+		case pattern::node_type::stmt: 
+			if (!isa<::block::stmt>(node)) return false; 
+			break;
+		case pattern::node_type::var:
+			// For var we will allow both vars and var_exprs
+			if (!isa<::block::var>(node) && !isa<::block::var_expr>(node)) return false;	
+			break;
+		case pattern::node_type::var_expr:
+			if (!isa<::block::var>(node)) return false;
+			if (p->children.size() > 0) {
+				block::Ptr child = to<::block::var_expr>(node);
+				if (!check_match(p->children[0], child, captures))
+					return false;
+			}
+			break;
+		case pattern::node_type::unary_expr:
+			if (!check_unary<::block::unary_expr>(p, node, captures)) return false;
+			break;
+		case pattern::node_type::binary_expr:
+			if (!check_binary<::block::binary_expr>(p, node, captures)) return false;
+			break;
+		case pattern::node_type::not_expr:
+			if (!check_unary<::block::not_expr>(p, node, captures)) return false;
+			break;	
+		case pattern::node_type::unary_minus_expr:
+			if (!check_unary<::block::not_expr>(p, node, captures)) return false;
+			break;
+		case pattern::node_type::bitwise_not_expr:
+			if (!check_unary<::block::bitwise_not_expr>(p, node, captures)) return false;
+			break;
+		case pattern::node_type::addr_of_expr:
+			if (!check_unary<::block::addr_of_expr>(p, node, captures)) return false;
+			break;
+		case pattern::node_type::and_expr:
+			if (!check_binary<::block::and_expr>(p, node, captures)) return false;
+			break;
+		case pattern::node_type::bitwise_and_expr:
+			if (!check_binary<::block::bitwise_and_expr>(p, node, captures)) return false;
+			break;
+		case pattern::node_type::bitwise_or_expr:
+			if (!check_binary<::block::bitwise_or_expr>(p, node, captures)) return false;
+			break;
+		case pattern::node_type::bitwise_xor_expr:
+			if (!check_binary<::block::bitwise_xor_expr>(p, node, captures)) return false;
+			break;
+		case pattern::node_type::lshift_expr:
+			if (!check_binary<::block::lshift_expr>(p, node, captures)) return false;
+			break;
+		case pattern::node_type::rshift_expr:
+			if (!check_binary<::block::rshift_expr>(p, node, captures)) return false;
+			break;
+		case pattern::node_type::or_expr:
+			if (!check_binary<::block::or_expr>(p, node, captures)) return false;
+			break;
+		case pattern::node_type::plus_expr:
+			if (!check_binary<::block::plus_expr>(p, node, captures)) return false;
+			break;
+		case pattern::node_type::minus_expr:
+			if (!check_binary<::block::minus_expr>(p, node, captures)) return false;
+			break;
+		case pattern::node_type::mul_expr:
+			if (!check_binary<::block::mul_expr>(p, node, captures)) return false;
+			break;
+		case pattern::node_type::div_expr:
+			if (!check_binary<::block::div_expr>(p, node, captures)) return false;
+			break;
+		case pattern::node_type::lt_expr:
+			if (!check_binary<::block::lt_expr>(p, node, captures)) return false;
+			break;
+		case pattern::node_type::gt_expr:
+			if (!check_binary<::block::gt_expr>(p, node, captures)) return false;
+			break;
+		case pattern::node_type::lte_expr:
+			if (!check_binary<::block::lte_expr>(p, node, captures)) return false;
+			break;
+		case pattern::node_type::gte_expr:
+			if (!check_binary<::block::gte_expr>(p, node, captures)) return false;
+			break;
+		case pattern::node_type::equals_expr:
+			if (!check_binary<::block::equals_expr>(p, node, captures)) return false;
+			break;
+		case pattern::node_type::ne_expr:
+			if (!check_binary<::block::ne_expr>(p, node, captures)) return false;
+			break;
+		case pattern::node_type::mod_expr:
+			if (!check_binary<::block::mod_expr>(p, node, captures)) return false;
+			break;
+		case pattern::node_type::assign_expr:
+			if (!isa<::block::assign_expr>(node)) return false;
+			if (p->children.size() > 0) {
+				block::Ptr child1 = to<::block::assign_expr>(node)->var1;
+				block::Ptr child2 = to<::block::assign_expr>(node)->expr1;
+				if (!check_match(p->children[0], child1, captures)) return false;
+				if (!check_match(p->children[1], child2, captures)) return false;
+			}
+			break;
+		case pattern::node_type::const_expr:
+			if (!isa<::block::const_expr>(node)) return false;	
+			break;
+		case pattern::node_type::int_const:
+			if (!isa<::block::int_const>(node)) return false;
+			if (p->has_const) {
+				long long val = to<::block::int_const>(node)->value;
+				if (p->const_val_int != val) 
+					return false;
+			}
+			break;
+		case pattern::node_type::double_const:
+		case pattern::node_type::float_const:
+			if (!isa<::block::double_const>(node) && !isa<::block::float_const>(node)) return false;
+			if (p->has_const) {
+				double val;
+				if (isa<::block::double_const>(node))
+					val = to<::block::int_const>(node)->value;
+				else 
+					val = to<::block::float_const>(node)->value;
+
+				if (p->const_val_double != val) 
+					return false;
+			}
+			break;
+		case pattern::node_type::string_const:
+			if (!isa<::block::string_const>(node)) return false;
+			if (p->has_const) {
+				std::string val = to<::block::string_const>(node)->value;
+				if (p->const_val_string != val) 
+					return false;
+			}
+			break;
+		case pattern::node_type::sq_bkt_expr:
+			if (!isa<::block::sq_bkt_expr>(node)) return false;
+			if (p->children.size() > 0) {
+				block::Ptr child1 = to<::block::sq_bkt_expr>(node)->var_expr;
+				block::Ptr child2 = to<::block::sq_bkt_expr>(node)->index;
+				if (!check_match(p->children[0], child1, captures)) return false;
+				if (!check_match(p->children[1], child2, captures)) return false;
+			}
+			break;
+		case pattern::node_type::function_call_expr:
+			if (!isa<::block::function_call_expr>(node)) return false;
+			// For now we will only check if it is a function call
+			break;
+		case pattern::node_type::initializer_list_expr:
+			if (!isa<::block::initializer_list_expr>(node)) return false;
+			// No checks for now
+			break;
+		case pattern::node_type::member_access_expr:
+			if (!isa<::block::member_access_expr>(node)) return false;
+			break;
+		default:
+			PATTERN_ASSERT(false, "Node type not implemented in pattern matcher");
+	}
+	// Now that we have ascertained the structure, check for bindings in captures
+	if (p->name != "") {
+		// Special matching updates
+		if (p->type == pattern::node_type::var && isa<::block::var_expr>(node)) {
+			node = to<::block::var_expr>(node)->var1;
+		}
+	
+		if (captures.find(p->name) != captures.end()) {
+			// This variable has already had a match, make sure they are the same
+			if (!node->is_same(captures[p->name])) 
+				return false;
+		} else {
+			// Update captures
+			captures[p->name] = node;
+		}
+	}
+
+	// Everthing is good, return true
+	return true;
+}
+struct matcher_visitor: public block_visitor {
+	std::vector<match> collected_matches;
+	std::shared_ptr<pattern> p;
+	void try_match(block::Ptr node) {
+		std::map<std::string, block::Ptr> captures;
+		if (check_match(p, node, captures)) {
+			match m;
+			m.node = node;
+			m.captures = std::move(captures);
+			collected_matches.push_back(std::move(m));
+		}
+	}
+	using block_visitor::visit;
+	virtual void visit(std::shared_ptr<::block::not_expr> a) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::unary_minus_expr> a) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::bitwise_not_expr> a) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::and_expr> a) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::bitwise_and_expr> a) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::bitwise_or_expr> a) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::bitwise_xor_expr> a) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::lshift_expr> a) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::rshift_expr> a) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::or_expr> a) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::plus_expr> a) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::minus_expr> a) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::mul_expr> a) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::div_expr> a) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::lt_expr> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::gt_expr> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::lte_expr> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::gte_expr> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::equals_expr> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::ne_expr> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::mod_expr> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::var_expr> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::int_const> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::double_const> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::float_const> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::string_const> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::assign_expr> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::expr_stmt> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::stmt_block> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::decl_stmt> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::if_stmt> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::label> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::label_stmt> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::goto_stmt> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::while_stmt> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::for_stmt> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::break_stmt> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::continue_stmt> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::sq_bkt_expr> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::function_call_expr> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::initializer_list_expr> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+
+	virtual void visit(std::shared_ptr<::block::member_access_expr> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::addr_of_expr> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+
+	virtual void visit(std::shared_ptr<::block::var> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::scalar_type> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::pointer_type> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::function_type> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::array_type> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::builder_var_type> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::named_type> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+
+	virtual void visit(std::shared_ptr<::block::func_decl> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+	virtual void visit(std::shared_ptr<::block::return_stmt> a ) {
+		block_visitor::visit(a);
+		try_match(a);
+	}
+};
+std::vector<match> find_all_matches(std::shared_ptr<pattern> p, block::Ptr node) {
+	matcher_visitor visitor;
+	visitor.p = p;
+	node->accept(&visitor);
+	return visitor.collected_matches;
+}
+
+}
+}

--- a/src/blocks/replacers.cpp
+++ b/src/blocks/replacers.cpp
@@ -1,0 +1,212 @@
+#include "blocks/matchers/matchers.h"
+#include "blocks/matchers/replacers.h"
+#include "blocks/block_replacer.h"
+#include "blocks/block.h"
+#include "blocks/stmt.h"
+#include "blocks/expr.h"
+#include "blocks/var.h"
+#include <memory>
+#include <map>
+#include <iostream>
+namespace block {
+namespace matcher {
+
+static bool replacer_error(bool error, std::string message) {
+	if (!error) {
+		std::cerr << "PM (replacer) error: " << message << std::endl;
+		return false;
+	}
+	return true;
+}
+#define REPLACER_ASSERT(expr, message) if (!replacer_error(expr, message)) return nullptr
+
+static block::Ptr create_ast(pattern::Ptr p, const std::map<std::string, block::Ptr>& matches);
+
+static inline expr::Ptr create_expr_ast(pattern::Ptr p, const std::map<std::string, block::Ptr>& matches) {
+	block::Ptr b = create_ast(p, matches);
+	// Special case, handle var where var_expr are expected
+	if (::block::isa<::block::var>(b)) {
+		::block::var_expr::Ptr ve = std::make_shared<::block::var_expr>();
+		ve->var1 = ::block::to<::block::var>(b);
+		b = ve;
+	}
+	REPLACER_ASSERT(::block::isa<::block::expr>(b), "Replacer does not create an expr");
+	return ::block::to<::block::expr>(b);
+}
+
+template <typename T>
+block::Ptr create_unary_ast(pattern::Ptr p, const std::map<std::string, block::Ptr>& matches) {
+	REPLACER_ASSERT(p->children.size() == 1 || p->name != "", "Specialized Unary Expr replacer must have one child or must reference a capture");
+	if (p->children.size()) {
+		typename T::Ptr t = std::make_shared<T>();
+		t->expr1 = create_expr_ast(p->children[0], matches);
+		return t;
+	}
+	return matches.at(p->name);
+}
+
+
+template <typename T>
+block::Ptr create_binary_ast(pattern::Ptr p, const std::map<std::string, block::Ptr>& matches) {
+	REPLACER_ASSERT(p->children.size() == 2 || p->name != "", "Specialized Binary expr replacer must have 2 children or must reference a capture");
+	if (p->children.size() == 2) {
+		typename T::Ptr t = std::make_shared<T>();
+		t->expr1 = create_expr_ast(p->children[0], matches);
+		t->expr2 = create_expr_ast(p->children[1], matches);
+		return t;
+	}
+	return matches.at(p->name);
+}
+
+
+block::Ptr create_ast(pattern::Ptr p, const std::map<std::string, block::Ptr>& matches) {
+	// This is a recursive function that will create the whole pattern
+	// matches is read-only
+	switch (p->type) {
+		case pattern::node_type::block: 
+			REPLACER_ASSERT(p->name != "", "Generic Block replacer must reference a capture");
+			return matches.at(p->name);
+		case pattern::node_type::expr:
+			REPLACER_ASSERT(p->name != "", "Generic Expr replacer must reference a capture");
+			return matches.at(p->name);	
+		case pattern::node_type::unary_expr:
+			REPLACER_ASSERT(p->name != "", "Generic Unary Expr replacer must reference a capture");
+			return matches.at(p->name);
+		case pattern::node_type::binary_expr:
+			REPLACER_ASSERT(p->name != "", "Generic Binary Expr replacer must reference a capture");
+			return matches.at(p->name);
+		case pattern::node_type::not_expr:
+			return create_unary_ast<::block::not_expr>(p, matches);
+		case pattern::node_type::unary_minus_expr:
+			return create_unary_ast<::block::unary_minus_expr>(p, matches);
+		case pattern::node_type::bitwise_not_expr:
+			return create_unary_ast<::block::bitwise_not_expr>(p, matches);
+		case pattern::node_type::and_expr:
+			return create_binary_ast<::block::and_expr>(p, matches);
+		case pattern::node_type::bitwise_and_expr:
+			return create_binary_ast<::block::bitwise_and_expr>(p, matches);
+		case pattern::node_type::bitwise_or_expr:
+			return create_binary_ast<::block::bitwise_or_expr>(p, matches);
+		case pattern::node_type::bitwise_xor_expr:
+			return create_binary_ast<::block::bitwise_xor_expr>(p, matches);
+		case pattern::node_type::lshift_expr:
+			return create_binary_ast<::block::lshift_expr>(p, matches);
+		case pattern::node_type::rshift_expr:
+			return create_binary_ast<::block::rshift_expr>(p, matches);
+		case pattern::node_type::or_expr:
+			return create_binary_ast<::block::or_expr>(p, matches);
+		case pattern::node_type::plus_expr:
+			return create_binary_ast<::block::plus_expr>(p, matches);
+		case pattern::node_type::minus_expr:
+			return create_binary_ast<::block::minus_expr>(p, matches);
+		case pattern::node_type::mul_expr:
+			return create_binary_ast<::block::mul_expr>(p, matches);
+		case pattern::node_type::div_expr:
+			return create_binary_ast<::block::div_expr>(p, matches);
+		case pattern::node_type::lt_expr:
+			return create_binary_ast<::block::lt_expr>(p, matches);
+		case pattern::node_type::gt_expr:
+			return create_binary_ast<::block::gt_expr>(p, matches);
+		case pattern::node_type::lte_expr:
+			return create_binary_ast<::block::lte_expr>(p, matches);
+		case pattern::node_type::gte_expr:
+			return create_binary_ast<::block::gte_expr>(p, matches);
+		case pattern::node_type::equals_expr:
+			return create_binary_ast<::block::equals_expr>(p, matches);
+		case pattern::node_type::ne_expr:
+			return create_binary_ast<::block::ne_expr>(p, matches);
+		case pattern::node_type::mod_expr:
+			return create_binary_ast<::block::mod_expr>(p, matches);
+		case pattern::node_type::var_expr:
+			REPLACER_ASSERT(p->children.size() == 1 || p->name != "", "Var Expr replacer must have a child or reference a capture");
+			if (p->children.size()) {
+				::block::var_expr::Ptr ve = std::make_shared<::block::var_expr>();
+				ve->var1 = ::block::to<::block::var>(create_ast(p->children[0], matches));
+			}
+			return matches.at(p->name);
+		case pattern::node_type::const_expr:
+			REPLACER_ASSERT(p->name != "", "Generic const Expr replacer must reference a capture");
+			return matches.at(p->name);
+		case pattern::node_type::int_const:
+			REPLACER_ASSERT(p->has_const || p->name != "", "Int const replacer must have a value or reference a capture");
+			if (p->has_const) {
+				::block::int_const::Ptr ic = std::make_shared<::block::int_const>();
+				ic->value = p->const_val_int;
+				return ic;
+			}
+			return matches.at(p->name);
+		case pattern::node_type::double_const:
+			REPLACER_ASSERT(p->has_const || p->name != "", "Double const replacer must have a value or reference a capture");
+			if (p->has_const) {
+				::block::double_const::Ptr dc = std::make_shared<::block::double_const>();
+				dc->value = p->const_val_double;
+				return dc;
+			}
+			return matches.at(p->name);
+		case pattern::node_type::float_const:
+			REPLACER_ASSERT(p->has_const || p->name != "", "Float const replacer must have a value or reference a capture");
+			if (p->has_const) {
+				::block::float_const::Ptr fc = std::make_shared<::block::float_const>();
+				fc->value = p->const_val_double;
+				return fc;
+			}
+			return matches.at(p->name);
+		case pattern::node_type::string_const:
+			REPLACER_ASSERT(p->has_const || p->name != "", "String const replacer must have a value or reference a capture");
+			if (p->has_const) {
+				::block::string_const::Ptr sc = std::make_shared<::block::string_const>();
+				sc->value = p->const_val_string;
+				return sc;
+			}
+			return matches.at(p->name);
+		case pattern::node_type::assign_expr:
+			REPLACER_ASSERT(p->children.size() == 2 || p->name != "", "Assign expr replacer must have 2 children or must reference a capture");
+			if (p->children.size() == 2) {
+				::block::assign_expr::Ptr t = std::make_shared<::block::assign_expr>();
+				t->var1 = create_expr_ast(p->children[0], matches);
+				t->expr1 = create_expr_ast(p->children[1], matches);
+				return t;
+			}
+			return matches.at(p->name);
+		case pattern::node_type::sq_bkt_expr:
+			REPLACER_ASSERT(p->children.size() == 2 || p->name != "", "Sq Bkt expr replacer must have 2 children or must reference a capture");
+			if (p->children.size() == 2) {
+				::block::sq_bkt_expr::Ptr t = std::make_shared<::block::sq_bkt_expr>();
+				t->var_expr = create_expr_ast(p->children[0], matches);
+				t->index = create_expr_ast(p->children[1], matches);
+				return t;
+			}
+			return matches.at(p->name);
+		case pattern::node_type::function_call_expr:	
+			REPLACER_ASSERT(p->name != "", "Function call replacer currently only supports replacing with a reference to a capture");
+			return matches.at(p->name);
+		case pattern::node_type::initializer_list_expr:
+			REPLACER_ASSERT(p->name != "", "Init list expr replacer currently only supports replacing with a reference to a capture");
+			return matches.at(p->name);
+		case pattern::node_type::member_access_expr:
+			REPLACER_ASSERT(p->name != "", "Member access expr replacer currently only supports replacing with a reference to a capture");
+			return matches.at(p->name);
+		case pattern::node_type::addr_of_expr:
+			return create_unary_ast<::block::addr_of_expr>(p, matches);
+		case pattern::node_type::var:
+			REPLACER_ASSERT(p->name != "", "Var replacer must reference a capture");
+			return matches.at(p->name);
+		default:
+			REPLACER_ASSERT(false, "This replacer is currently not supported");		
+			return nullptr;
+	}
+	return nullptr;
+}
+
+void replace_match(block::Ptr ast, match m, pattern::Ptr p) {
+	// Before we replace the match with the new AST, first generate the asts 
+	// using the new pattern and the captures
+	block::Ptr replacement = create_ast(p, m.captures);
+	block_replacer replacer;
+	replacer.to_replace = m.node;
+	replacer.replace_with = replacement;
+	ast->accept(&replacer);
+}
+
+}
+}


### PR DESCRIPTION
This changeset adds two new features - 

1. Added basic support for nd_vars<T> a new type for sampling and constraining non-deterministic values. The use case is for implementing backward data-flow analyses. Currently support for nd_vars<bool> has been added. bool supports a basic requires_equal function. Sample 61 has been added to test the same. 

2. Merged support for pattern matches: A new type matcher::pattern has been introduced that allows expressing patterns with arbitrary level of abstraction. Two interfaces for matchers and replacers have been introduced. patterns support captures of named expressions and common overloads for simplifying pattern creation. Support for statement matching will be added later. Sample 62 has been added to test the same.  