### PR TITLE
Fixed bug with dyn_var<T*> requiring T to be completely defined

### DIFF
--- a/include/builder/dyn_var.h
+++ b/include/builder/dyn_var.h
@@ -440,12 +440,17 @@ public:
 		return (cast)(this->dyn_var_impl<T*>::operator*());
 	}
 	// Hack for creating a member that's live across return site
-	dyn_var<T> _p = as_member(this, "_p");
+	
+	std::unique_ptr<dyn_var<T>> _p = nullptr;
+
 	dyn_var<T> *operator->() {
 		auto b = this->operator[](0);
 		b.encompassing_expr->template setMetadata<bool>("deref_is_star", true);
-		_p = (cast)b;
-		return _p.addr();
+		if (_p == nullptr) {
+			_p = std::unique_ptr<dyn_var<T>>(new dyn_var<T>(as_member(this, "_p")));	
+		}
+		*_p = (cast)b;
+		return _p->addr();
 	}
 };
 

--- a/samples/outputs.var_names/sample63
+++ b/samples/outputs.var_names/sample63
@@ -1,0 +1,5 @@
+void bar (void) {
+  linked_list* x_0;
+  ((x_0->next)->next)->next = 0;
+}
+

--- a/samples/outputs/sample63
+++ b/samples/outputs/sample63
@@ -1,0 +1,5 @@
+void bar (void) {
+  linked_list* var0;
+  ((var0->next)->next)->next = 0;
+}
+

--- a/samples/sample63.cpp
+++ b/samples/sample63.cpp
@@ -1,0 +1,29 @@
+// Include the headers
+#include "blocks/c_code_generator.h"
+#include "builder/static_var.h"
+#include "builder/dyn_var.h"
+#include "blocks/rce.h"
+#include <iostream>
+
+// Include the BuildIt types
+using builder::dyn_var;
+using builder::static_var;
+
+struct linked_list {
+	static constexpr const char* type_name = "linked_list";
+	dyn_var<linked_list*> next = builder::with_name("next");
+};
+
+static void bar(void) {
+	dyn_var<struct linked_list*> x;
+	x->next->next->next = 0;
+}
+
+int main(int argc, char* argv[]) {
+	builder::builder_context context;
+	auto ast = context.extract_function_ast(bar, "bar");
+	block::c_code_generator::generate_code(ast, std::cout, 0);
+	return 0;
+}
+
+


### PR DESCRIPTION
BuildIt had a bug with how it handles dyn_var<T*> for recursive types. A very common pattern like the following appears in linked list implementations - 

```
struct linked_list {
    dyn_var<linked_list*> next;
};
```
Typically declaring a pointer to a type doesn't require the type to be "complete". However the way dyn_var<T*> is implemented is it tries to create an object of type dyn_var<T> inside to return when the ->/[] operator is called. Now this causes issues because dyn_var<T> requires T to be "complete" since it inherits from T when T is a struct type. 

This causes the above sample to fail with compile error. 

To fix this we make the extra member of type dyn_var<T> inside dyn_var<T*> be created lazily. We change the member to be of type std::unique_ptr<dyn_var<T>> and allocate it when it is first required. 

Sample63 has been added to test this 