### PR TITLE
Added support for external type namers

### DIFF
--- a/include/builder/dyn_var.h
+++ b/include/builder/dyn_var.h
@@ -441,13 +441,13 @@ public:
 	}
 	// Hack for creating a member that's live across return site
 	
-	std::unique_ptr<dyn_var<T>> _p = nullptr;
+	std::shared_ptr<dyn_var<T>> _p = nullptr;
 
 	dyn_var<T> *operator->() {
 		auto b = this->operator[](0);
 		b.encompassing_expr->template setMetadata<bool>("deref_is_star", true);
 		if (_p == nullptr) {
-			_p = std::unique_ptr<dyn_var<T>>(new dyn_var<T>(as_member(this, "_p")));	
+			_p = std::make_shared<dyn_var<T>>(as_member(this, "_p"));
 		}
 		*_p = (cast)b;
 		return _p->addr();

--- a/samples/outputs.var_names/sample63
+++ b/samples/outputs.var_names/sample63
@@ -1,5 +1,10 @@
+struct linked_list {
+  linked_list* next;
+  struct foo* other;
+};
 void bar (void) {
   linked_list* x_0;
   ((x_0->next)->next)->next = 0;
+  x_0->other = 0;
 }
 

--- a/samples/outputs/sample63
+++ b/samples/outputs/sample63
@@ -1,5 +1,10 @@
+struct linked_list {
+  linked_list* next;
+  struct foo* other;
+};
 void bar (void) {
   linked_list* var0;
   ((var0->next)->next)->next = 0;
+  var0->other = 0;
 }
 

--- a/samples/sample63.cpp
+++ b/samples/sample63.cpp
@@ -9,17 +9,30 @@
 using builder::dyn_var;
 using builder::static_var;
 
+struct foo;
+
+// Mechanism for assigning names to incomplete types
+namespace builder {
+template <>
+struct external_type_namer<foo> {
+	static constexpr const char* type_name = "struct foo";
+};
+}
+
 struct linked_list {
 	static constexpr const char* type_name = "linked_list";
 	dyn_var<linked_list*> next = builder::with_name("next");
+	dyn_var<foo*> other = builder::with_name("other");
 };
 
 static void bar(void) {
 	dyn_var<struct linked_list*> x;
 	x->next->next->next = 0;
+	x->other = 0;
 }
 
 int main(int argc, char* argv[]) {
+	block::c_code_generator::generate_struct_decl<dyn_var<linked_list>>(std::cout);
 	builder::builder_context context;
 	auto ast = context.extract_function_ast(bar, "bar");
 	block::c_code_generator::generate_code(ast, std::cout, 0);


### PR DESCRIPTION
BuildIt had an issue where incomplete types cannot be given names without completing them. Ideally users shouldn't use incomplete types in BuildIt code bases, however when migrating C code containing stdio.h headers this seems to be a recurring theme. 

So we are now supporting _yet another way to name_ struct types using the type trait external_type_namer. 

Sample63 has been udpated to test the same. 