### PR TITLE
make sure uint32_t is defined

### DIFF
--- a/include/builder/builder_context.h
+++ b/include/builder/builder_context.h
@@ -9,6 +9,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+#include <cstdint>
 
 namespace builder {
 


### PR DESCRIPTION
Added `#include <cstdint>` to builder_context.h to fix the following compile error:

```
CXX    annotate.o
In file included from /home/chillenb/src/buildit/include/builder/builder_base.h:8,
                 from /home/chillenb/src/buildit/include/builder/builder.h:3,
                 from /home/chillenb/src/buildit/src/builder/annotate.cpp:1:
/home/chillenb/src/buildit/include/builder/builder_context.h:25:9: error: ‘uint32_t’ does not name a type
   25 |         uint32_t size;
      |         ^~~~~~~~
/home/chillenb/src/buildit/include/builder/builder_context.h:11:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
   10 | #include <unordered_set>
  +++ |+#include <cstdint>
   11 | #include <vector>
```