### PR TITLE
adapt to breaking changes in libdwarf api

### DIFF
--- a/make/setvars.mk
+++ b/make/setvars.mk
@@ -56,15 +56,16 @@ endif
 
 LIBUNWIND_PATH ?= _UNSET_
 ifeq ($(RECOVER_VAR_NAMES),1)
-LINKER_FLAGS+=-ldwarf -lunwind
+LINKER_FLAGS+=$(shell pkg-config --libs libdwarf libunwind)
 CFLAGS_INTERNAL+=-DRECOVER_VAR_NAMES
+INCLUDE_FLAGS+=$(shell pkg-config --cflags libdwarf)
 ifneq ($(LIBUNWIND_PATH),_UNSET_)
 INCLUDE_FLAGS+=-I $(LIBUNWIND_PATH)/include
 LINKER_FLAGS+=-L $(LIBUNWIND_PATH)/lib
 endif
 else
 ifeq ($(TRACER_USE_LIBUNWIND),1)
-LINKER_FLAGS+=-lunwind
+LINKER_FLAGS+=$(shell pkg-config --libs libunwind)
 ifneq ($(LIBUNWIND_PATH),_UNSET_)
 INCLUDE_FLAGS+=-I $(LIBUNWIND_PATH)/include
 LINKER_FLAGS+=-L $(LIBUNWIND_PATH)/lib


### PR DESCRIPTION
I ran into some issues trying to use variable name recovery:

- The libdwarf provided by my OS is too new; it's missing a bunch of deprecated symbols (dwarf_siblingof, etc). This is my attempt to use the recommended replacement functions. I know very little about libdwarf, but it seems to pass the tests.
- For some reason, my libdwarf headers are located at `/usr/include/libdwarf-2`, not `/usr/include/libdwarf`. I changed the makefiles to find the right directory with pkg-config. Does it work on your system?