### PR TITLE
Support for general types inside static_var

### DIFF
--- a/include/blocks/label_inserter.h
+++ b/include/blocks/label_inserter.h
@@ -16,7 +16,7 @@ class label_creator : public block_visitor {
 public:
 	using block_visitor::visit;
 	std::vector<tracer::tag> collected_labels;
-	std::unordered_map<std::string, label::Ptr> offset_to_label;
+	std::unordered_map<tracer::tag, label::Ptr> offset_to_label;
 	int current_label = 0;
 	virtual void visit(stmt_block::Ptr);
 };
@@ -27,10 +27,10 @@ public:
 	// The main table to hold static tag to label mapping
 	// this table holds the jump target that is in the parent of the
 	// jump statement
-	std::unordered_map<std::string, label::Ptr> offset_to_label;
+	std::unordered_map<tracer::tag, label::Ptr> offset_to_label;
 	// A backup table which has atleast one label that we can jump to
 	// Only used when feature_unstructured is used
-	std::unordered_map<std::string, label::Ptr> backup_offset_to_label;
+	std::unordered_map<tracer::tag, label::Ptr> backup_offset_to_label;
 
 	bool feature_unstructured;
 

--- a/include/blocks/var_namer.h
+++ b/include/blocks/var_namer.h
@@ -11,8 +11,8 @@ namespace block {
 class var_gather_escapes : public block_visitor {
 public:
 	using block_visitor::visit;
-	std::vector<std::string> &escaping_tags;
-	var_gather_escapes(std::vector<std::string> &e) : escaping_tags(e) {}
+	std::vector<tracer::tag> &escaping_tags;
+	var_gather_escapes(std::vector<tracer::tag> &e) : escaping_tags(e) {}
 	virtual void visit(decl_stmt::Ptr) override;
 };
 
@@ -20,11 +20,11 @@ class var_namer : public block_visitor {
 public:
 	using block_visitor::visit;
 	int var_counter = 0;
-	std::map<std::string, var::Ptr> collected_decls;
-	std::map<std::string, decl_stmt::Ptr> decls_to_hoist;
-	std::vector<std::string> decl_tags_to_hoist;
+	std::unordered_map<tracer::tag, var::Ptr> collected_decls;
+	std::unordered_map<tracer::tag, decl_stmt::Ptr> decls_to_hoist;
+	std::vector<tracer::tag> decl_tags_to_hoist;
 
-	std::vector<std::string> escaping_tags;
+	std::vector<tracer::tag> escaping_tags;
 
 	virtual void visit(decl_stmt::Ptr) override;
 
@@ -34,9 +34,9 @@ public:
 class var_replacer : public block_visitor {
 public:
 	using block_visitor::visit;
-	std::map<std::string, var::Ptr> &collected_decls;
-	std::vector<std::string> &escaping_tags;
-	var_replacer(std::map<std::string, var::Ptr> &d, std::vector<std::string> &e)
+	std::unordered_map<tracer::tag, var::Ptr> &collected_decls;
+	std::vector<tracer::tag> &escaping_tags;
+	var_replacer(std::unordered_map<tracer::tag, var::Ptr> &d, std::vector<tracer::tag> &e)
 	    : collected_decls(d), escaping_tags(e) {}
 
 	virtual void visit(var_expr::Ptr) override;
@@ -45,9 +45,9 @@ public:
 class var_hoister : public block_replacer {
 public:
 	using block_replacer::visit;
-	std::map<std::string, decl_stmt::Ptr> &decls_to_hoist;
-	std::vector<std::string> &escaping_tags;
-	var_hoister(std::map<std::string, decl_stmt::Ptr> &d, std::vector<std::string> &e)
+	std::unordered_map<tracer::tag, decl_stmt::Ptr> &decls_to_hoist;
+	std::vector<tracer::tag> &escaping_tags;
+	var_hoister(std::unordered_map<tracer::tag, decl_stmt::Ptr> &d, std::vector<tracer::tag> &e)
 	    : decls_to_hoist(d), escaping_tags(e) {}
 	virtual void visit(decl_stmt::Ptr) override;
 };

--- a/include/builder/block_type_extractor.h
+++ b/include/builder/block_type_extractor.h
@@ -3,6 +3,7 @@
 
 
 #include "builder/forward_declarations.h"
+#include "util/mtp_utils.h"
 #include "builder/generics.h"
 #include <algorithm>
 
@@ -12,8 +13,6 @@ struct custom_type_base;
 
 template <typename T>
 struct external_type_namer;
-
-
 
 extern int type_naming_counter;
 
@@ -41,7 +40,7 @@ member or a external_namer specialization */
 template <typename T, typename V=void>
 struct has_type_name: public std::false_type {};
 template <typename T>
-struct has_type_name<T, typename check_valid_type<decltype(T::type_name)>::type>: public std::true_type {};
+struct has_type_name<T, typename utils::check_valid_type<decltype(T::type_name)>::type>: public std::true_type {};
 
 template <typename T>
 struct type_namer<T, typename std::enable_if<has_type_name<external_type_namer<T>>::value>::type> {
@@ -66,14 +65,14 @@ struct type_template {
 };
 
 template <typename T>
-struct type_template<T, typename check_valid_type<decltype(T::get_template_arg_types)>::type> {
+struct type_template<T, typename utils::check_valid_type<decltype(T::get_template_arg_types)>::type> {
 	static std::vector<block::type::Ptr> get_templates() {
 		return T::get_template_arg_types();
 	}
 };
 
 template <typename T>
-struct type_template<T, typename check_valid_type<decltype(external_type_namer<T>::get_template_arg_types)>::type> {
+struct type_template<T, typename utils::check_valid_type<decltype(external_type_namer<T>::get_template_arg_types)>::type> {
 	static std::vector<block::type::Ptr> get_templates() {
 		return external_type_namer<T>::get_template_arg_types();
 	}

--- a/include/builder/builder_context.h
+++ b/include/builder/builder_context.h
@@ -18,31 +18,10 @@ block::expr::Ptr create_foreign_expr(const T t);
 template <typename T>
 builder create_foreign_expr_builder(const T t);
 
-class static_var_base;
-
-class tracking_tuple {
-public:
-	const unsigned char *ptr;
-	uint32_t size;
-	static_var_base *var_ref;
-
-	tracking_tuple(const unsigned char *_ptr, uint32_t _size, static_var_base *_var_ref)
-	    : ptr(_ptr), size(_size), var_ref(_var_ref) {}
-
-	std::string snapshot(void) {
-		std::string output_string;
-		char temp[4];
-		for (unsigned int i = 0; i < size; i++) {
-			sprintf(temp, "%02x", ptr[i]);
-			output_string += temp;
-		}
-		return output_string;
-	}
-};
 
 class tag_map {
 public:
-	std::unordered_map<std::string, block::stmt_block::Ptr> map;
+	std::unordered_map<tracer::tag, block::stmt_block::Ptr> map;
 };
 
 void lambda_wrapper(std::function<void(void)>);
@@ -67,21 +46,21 @@ public:
 	block::stmt::Ptr ast;
 	block::stmt_block::Ptr current_block_stmt;
 	std::vector<bool> bool_vector;
-	std::unordered_set<std::string> visited_offsets;
+	std::unordered_set<tracer::tag> visited_offsets;
 	std::vector<block::expr::Ptr> expr_sequence;
 	unsigned long long expr_counter = 0;
 	std::string current_label;
 
-	std::vector<tracking_tuple> static_var_tuples;
-	std::vector<tracking_tuple> deferred_static_var_tuples;
+	std::vector<static_var_base*> static_var_tuples;
+	std::vector<static_var_base*> deferred_static_var_tuples;
 
 	// Run shared state
 	tag_map _internal_tags;
 	tag_map *memoized_tags;
 
 	// State shared across non-deterministic failures
-	std::unordered_map<std::string, std::shared_ptr<nd_var_gen_base>> *nd_state_map = nullptr;
-	std::unordered_map<std::string, std::shared_ptr<nd_var_gen_base>> _nd_state_map;
+	std::unordered_map<tracer::tag, std::shared_ptr<nd_var_gen_base>> *nd_state_map = nullptr;
+	std::unordered_map<tracer::tag, std::shared_ptr<nd_var_gen_base>> _nd_state_map;
 
 	void reset_for_nd_failure();
 	

--- a/include/builder/dyn_var.h
+++ b/include/builder/dyn_var.h
@@ -3,6 +3,7 @@
 
 #include "builder/builder.h"
 #include "util/var_finder.h"
+#include "util/mtp_utils.h"
 namespace builder {
 
 namespace options {
@@ -125,7 +126,7 @@ public:
 			dyn_var->var_type = create_block_type();
 			block_var = dyn_var;
 			// Don't try to obtain preferred names for objects created without context
-			// dyn_var->preferred_name = util::find_variable_name(this);
+			// dyn_var->preferred_name = utils::find_variable_name(this);
 			return;
 		}
 		assert(builder_context::current_builder_context != nullptr);
@@ -134,7 +135,7 @@ public:
 		block::var::Ptr dyn_var = std::make_shared<block::var>();
 		dyn_var->var_type = create_block_type();
 		tracer::tag offset = get_offset_in_function();
-		dyn_var->preferred_name = util::find_variable_name_cached(this, offset.stringify());
+		dyn_var->preferred_name = utils::find_variable_name_cached(this, offset);
 		block_var = dyn_var;
 		dyn_var->static_offset = offset;
 		block_decl_stmt = nullptr;
@@ -363,7 +364,7 @@ struct dyn_var_deref_provider {
 };
 
 template <typename T>
-struct dyn_var_deref_provider<T, typename check_valid_type<typename T::dereference_type>::type> {
+struct dyn_var_deref_provider<T, typename utils::check_valid_type<typename T::dereference_type>::type> {
 	dyn_var_mimic<typename T::dereference_type> operator[] (const builder& b) {
 		return (cast)(static_cast<dyn_var<T>*>(this)->dyn_var_impl<T>::operator[](b));
 	}

--- a/include/builder/forward_declarations.h
+++ b/include/builder/forward_declarations.h
@@ -16,6 +16,8 @@ using is_builder_type = typename std::is_same<builder, T>;
 template <typename T>
 using if_builder = typename std::enable_if<is_builder_type<T>::value, T>::type;
 
+class static_var_base;
+
 template <typename T>
 class static_var;
 
@@ -58,11 +60,6 @@ struct with_name {
 	std::string name;
 	bool with_decl;
 	with_name(const std::string &n, bool wd = false) : name(n), with_decl(wd) {}
-};
-
-template <typename T>
-struct check_valid_type {
-	typedef void type;
 };
 
 // Generator states for non-deterministic values

--- a/include/builder/nd_var.h
+++ b/include/builder/nd_var.h
@@ -28,15 +28,13 @@ struct nd_var_gen<bool>: public nd_var_gen_base {
 
 template <typename T>
 std::shared_ptr<nd_var_gen<T>> get_or_create_generator(tracer::tag req_tag) {
-	std::string tag_name = req_tag.stringify();
-
-	if (builder_context::current_builder_context->nd_state_map->find(tag_name) ==
+	if (builder_context::current_builder_context->nd_state_map->find(req_tag) ==
 		builder_context::current_builder_context->nd_state_map->end()) {
-		(*(builder_context::current_builder_context->nd_state_map))[tag_name] = std::make_shared<nd_var_gen<T>>();
+		(*(builder_context::current_builder_context->nd_state_map))[req_tag] = std::make_shared<nd_var_gen<T>>();
 	}
 
 	return std::static_pointer_cast<nd_var_gen<T>>(
-		(*(builder_context::current_builder_context->nd_state_map))[tag_name]);
+		(*(builder_context::current_builder_context->nd_state_map))[req_tag]);
 }
 
 /* contstraints on bool types

--- a/include/builder/var_snapshots.h
+++ b/include/builder/var_snapshots.h
@@ -1,0 +1,131 @@
+#ifndef BUILDER_VAR_SNAPSHOTS_H
+#define BUILDER_VAR_SNAPSHOTS_H
+
+#include "util/mtp_utils.h"
+
+namespace builder {
+
+// A base class for all static variable snapshots
+// snapshots are shared_ptr allocated so that multiple tags
+// can freely share snapshots, also allows freely caching snapshots
+// to avoid excessive snapshot allocations
+
+class static_var_snapshot_base: std::enable_shared_from_this<static_var_snapshot_base> {
+public:
+	typedef std::shared_ptr<static_var_snapshot_base> Ptr;
+	virtual bool operator == (static_var_snapshot_base::Ptr other) = 0;
+	virtual ~static_var_snapshot_base();
+	virtual std::string serialize() = 0;
+
+	// A precomputed hash separate from all implementations
+	size_t computed_hash = 0;
+};
+
+template <typename T>
+class static_var_snapshot: public static_var_snapshot_base {
+public:
+	typedef std::shared_ptr<static_var_snapshot<T>> Ptr;
+
+	T snapshot;
+	// T needs to be copy constructible
+	static_var_snapshot (const T& s): snapshot(s) {
+		computed_hash = tracer::hash_helper<T>::get_hash(s);
+	}
+
+	bool operator == (static_var_snapshot_base::Ptr _other) {
+		if (computed_hash != _other->computed_hash) return false;
+		Ptr other = std::dynamic_pointer_cast<static_var_snapshot<T>>(_other);
+		if (!other) return false;
+		// T needs to be comparable
+		return (snapshot == other->snapshot);
+	}	
+	std::string serialize() {
+		return utils::can_to_string<T>::get_string(snapshot);
+	}
+};
+
+// Fixed sized arrays are handled differently
+template <typename T, size_t size>
+class static_var_snapshot<T[size]>: public static_var_snapshot_base {
+public:
+	typedef std::shared_ptr<static_var_snapshot<T[size]>> Ptr;
+	
+	// TODO: Can be optimized to use std::array, 
+	// but initialization needs std::index_sequence
+
+	std::vector<T> snapshot;
+	static_var_snapshot (const T* s): snapshot(s, s + size) {
+		if (snapshot.size() == 0) {
+			computed_hash = typeid(T).hash_code();
+		} else {
+			computed_hash = tracer::hash_helper<T>::get_hash(snapshot[0]);
+			for (unsigned i = 1; i < snapshot.size(); i++) {
+				computed_hash = tracer::hash_combine(
+					computed_hash, tracer::hash_helper<T>::get_hash(snapshot[i]));
+			}
+		}
+	}
+
+	bool operator == (static_var_snapshot_base::Ptr _other) {
+		if (computed_hash != _other->computed_hash) return false;
+		Ptr other = std::dynamic_pointer_cast<static_var_snapshot<T[size]>>(_other);
+		if (!other) return false;
+		// T needs to be comparable
+		return (snapshot == other->snapshot);
+	}	
+	std::string serialize() {
+		std::string output = "{";
+		for (unsigned int i = 0; i < snapshot.size(); i++) {
+			output += utils::can_to_string<T>::get_string(snapshot[i]);
+			if (i != snapshot.size() - 1)
+				output += ", ";
+		}
+		output += "}";
+		return output;
+	}
+};
+
+template <typename T>
+class static_var_snapshot<T[]>: public static_var_snapshot_base {
+public:
+	typedef std::shared_ptr<static_var_snapshot<T[]>> Ptr;
+	std::vector<T> snapshot;
+
+	// Flexible array sizes would accept an extra parameter
+	static_var_snapshot(const T* s, size_t size): snapshot(s, s + size) {
+		if (snapshot.size() == 0) {
+			computed_hash = typeid(T).hash_code();
+		} else {
+			computed_hash = tracer::hash_helper<T>::get_hash(snapshot[0]);
+			for (unsigned i = 1; i < snapshot.size(); i++) {
+				computed_hash = tracer::hash_combine(
+					computed_hash, tracer::hash_helper<T>::get_hash(snapshot[i]));
+			}
+		}
+	}
+
+	bool operator == (static_var_snapshot_base::Ptr _other) {
+		if (computed_hash != _other->computed_hash) return false;
+		Ptr other = std::dynamic_pointer_cast<static_var_snapshot<T[]>>(_other);
+		if (!other) return false;
+		// T needs to be comparable
+		return (snapshot == other->snapshot);
+	}	
+	std::string serialize() {
+		std::string output = "{";
+		for (unsigned int i = 0; i < snapshot.size(); i++) {
+			output += utils::can_to_string<T>::get_string(snapshot[i]);
+			if (i != snapshot.size() - 1)
+				output += ", ";
+		}
+		output += "}";
+		return output;
+	}
+};
+
+// We don't need tracking tuples any more since static_vars themselves act 
+// as tracking tuples
+
+}
+
+#endif 

--- a/include/util/hash_utils.h
+++ b/include/util/hash_utils.h
@@ -1,0 +1,30 @@
+#ifndef BUILDER_HASH_UTILS_H
+#define BUILDER_HASH_UTILS_H
+
+#include "util/mtp_utils.h"
+
+namespace tracer {
+// Just a hash_combine function
+static inline size_t hash_combine(size_t h1, size_t h2) {
+	// Boost's simple hash_combine. Works well for most cases
+	return h1 ^ (h2 + 0x9e3779b97f4a7c15ULL + (h1 << 6) + (h1 >> 2));
+}
+
+template <typename T, typename V=void>
+struct hash_helper {
+	// default case just returns hash of just the typeid
+	static inline size_t get_hash(const T& _) {
+		return typeid(T).hash_code();
+	}
+};
+
+template <typename T>
+struct hash_helper<T, typename utils::check_valid_type<decltype(std::hash<T>())>::type> {
+	static inline size_t get_hash(const T& t) {
+		return std::hash<T>{}(t);
+	}
+};
+
+}
+
+#endif

--- a/include/util/mtp_utils.h
+++ b/include/util/mtp_utils.h
@@ -1,0 +1,36 @@
+#ifndef BUILDER_MTP_UTILS_H
+#define BUILDER_MTP_UTILS_H
+
+#include <type_traits>
+#include <string>
+
+namespace utils {
+
+template <typename T>
+struct check_valid_type {
+	typedef void type;
+};
+
+template <typename T, typename V=void>
+struct has_operator_equal: std::false_type {};
+
+template <typename T>
+struct has_operator_equal<T, typename check_valid_type<decltype(std::declval<T>() == std::declval<T>())>::type>: std::true_type {};
+
+template <typename T, typename V=void>
+struct can_to_string {
+	static std::string get_string(const T& t) {
+		return "<no-str object>";
+	}
+};
+
+template <typename T>
+struct can_to_string<T, typename check_valid_type<decltype(std::to_string(std::declval<T>()))>::type> {
+	static std::string get_string(const T& t) {
+		return std::to_string(t);
+	}
+};
+
+}
+
+#endif

--- a/include/util/var_finder.h
+++ b/include/util/var_finder.h
@@ -1,10 +1,12 @@
 #ifndef UTIL_VAR_FINDER_H
 #define UTIL_VAR_FINDER_H
 #include <string>
-namespace util {
+#include "util/tracer.h"
+
+namespace utils {
 std::string find_variable_name(void *);
-std::string find_variable_name_cached(void *, std::string tag_string);
-extern std::string member_separator;
-} // namespace util
+std::string find_variable_name_cached(void *, tracer::tag stag);
+extern std::string ember_separator;
+} // namespace utils
 
 #endif

--- a/samples/outputs.var_names/sample65
+++ b/samples/outputs.var_names/sample65
@@ -1,0 +1,21 @@
+void bar (void) {
+  int y_0 = 0ll;
+  if (y_0 < 0ll) {
+    (y_0 = y_0 + 1) - 1;
+  } else {
+    (y_0 = y_0 - 1) + 1;
+  }
+  int y_1 = 1ll;
+  if (y_1 < 1ll) {
+    (y_1 = y_1 + 1) - 1;
+  } else {
+    (y_1 = y_1 - 1) + 1;
+  }
+  int y_2 = 2ll;
+  if (y_2 < 2ll) {
+    (y_2 = y_2 + 1) - 1;
+  } else {
+    (y_2 = y_2 - 1) + 1;
+  }
+}
+

--- a/samples/outputs/sample65
+++ b/samples/outputs/sample65
@@ -1,0 +1,21 @@
+void bar (void) {
+  int var0 = 0ll;
+  if (var0 < 0ll) {
+    (var0 = var0 + 1) - 1;
+  } else {
+    (var0 = var0 - 1) + 1;
+  }
+  int var1 = 1ll;
+  if (var1 < 1ll) {
+    (var1 = var1 + 1) - 1;
+  } else {
+    (var1 = var1 - 1) + 1;
+  }
+  int var2 = 2ll;
+  if (var2 < 2ll) {
+    (var2 = var2 + 1) - 1;
+  } else {
+    (var2 = var2 - 1) + 1;
+  }
+}
+

--- a/samples/sample65.cpp
+++ b/samples/sample65.cpp
@@ -1,0 +1,32 @@
+// Include the headers
+#include "blocks/c_code_generator.h"
+#include "builder/static_var.h"
+#include "builder/dyn_var.h"
+#include "blocks/rce.h"
+#include <iostream>
+
+// Include the BuildIt types
+using builder::dyn_var;
+using builder::static_var;
+
+static void bar(void) {
+	static_var<std::vector<int>> x;
+	while (x.val.size() < 3) {
+		dyn_var<int> y = x.val.size();
+		if (y < x.val.size()) {
+			y++;
+		} else {
+			y--;
+		}
+		x.val.push_back(2);
+	}
+} 
+
+int main(int argc, char* argv[]) {
+	builder::builder_context context;
+	auto ast = context.extract_function_ast(bar, "bar");
+	block::c_code_generator::generate_code(ast, std::cout, 0);
+	return 0;
+}
+
+

--- a/src/blocks/label_inserter.cpp
+++ b/src/blocks/label_inserter.cpp
@@ -13,8 +13,6 @@ void label_creator::visit(stmt_block::Ptr a) {
 		    collected_labels.end()) {
 			label::Ptr new_label = std::make_shared<label>();
 			new_label->static_offset = stmt->static_offset;
-			// new_label->label_name =
-			//"label" + stmt->static_offset.stringify();
 			new_label->label_name = "label" + std::to_string(current_label);
 			current_label++;
 			label_stmt::Ptr new_label_stmt = std::make_shared<label_stmt>();
@@ -22,7 +20,7 @@ void label_creator::visit(stmt_block::Ptr a) {
 			new_label_stmt->label1 = new_label;
 			new_stmts.push_back(new_label_stmt);
 
-			offset_to_label[stmt->static_offset.stringify()] = new_label;
+			offset_to_label[stmt->static_offset] = new_label;
 		}
 		new_stmts.push_back(stmt);
 		stmt->accept(this);
@@ -31,15 +29,15 @@ void label_creator::visit(stmt_block::Ptr a) {
 }
 
 void label_inserter::visit(label_stmt::Ptr a) {
-	offset_to_label[a->label1->static_offset.stringify()] = a->label1;
+	offset_to_label[a->label1->static_offset] = a->label1;
 }
 
 void label_inserter::visit(goto_stmt::Ptr a) {
 	// Pick any jump target with feature unstructured
 	// otherwise pick the one that is in the parent block
 	if (feature_unstructured)
-		a->label1 = backup_offset_to_label[a->temporary_label_number.stringify()];
+		a->label1 = backup_offset_to_label[a->temporary_label_number];
 	else
-		a->label1 = offset_to_label[a->temporary_label_number.stringify()];
+		a->label1 = offset_to_label[a->temporary_label_number];
 }
 } // namespace block

--- a/src/blocks/var_namer.cpp
+++ b/src/blocks/var_namer.cpp
@@ -13,23 +13,23 @@ void var_gather_escapes::visit(decl_stmt::Ptr stmt) {
 		if (!stmt->decl_var->hasMetadata<int>("allow_escape_scope") ||
 		    !stmt->decl_var->getMetadata<int>("allow_escape_scope")) {
 
-			std::string so_loc = stmt->decl_var->static_offset.stringify_loc();
+			tracer::tag so_loc = stmt->decl_var->static_offset.slice_loc();
 			if (std::find(escaping_tags.begin(), escaping_tags.end(), so_loc) == escaping_tags.end())
 				escaping_tags.push_back(so_loc);
 		}
 	}
 }
 
-static std::string get_apt_tag(var::Ptr a, std::vector<std::string> escaping_tags) {
-	std::string so_loc = a->static_offset.stringify_loc();
+static tracer::tag get_apt_tag(var::Ptr a, std::vector<tracer::tag> escaping_tags) {
+	tracer::tag so_loc = a->static_offset.slice_loc();
 	if (std::find(escaping_tags.begin(), escaping_tags.end(), so_loc) != escaping_tags.end())
 		return so_loc;
 	else
-		return a->static_offset.stringify();
+		return a->static_offset;
 }
 
 void var_namer::visit(decl_stmt::Ptr stmt) {
-	std::string so = get_apt_tag(stmt->decl_var, escaping_tags);
+	tracer::tag so = get_apt_tag(stmt->decl_var, escaping_tags);
 
 	if (collected_decls.find(so) != collected_decls.end()) {
 		// This decl has been seen before, and needs to be marked for hoisting
@@ -57,7 +57,7 @@ void var_namer::visit(decl_stmt::Ptr stmt) {
 }
 
 void var_replacer::visit(var_expr::Ptr a) {
-	std::string so = get_apt_tag(a->var1, escaping_tags);
+	tracer::tag so = get_apt_tag(a->var1, escaping_tags);
 
 	if (collected_decls.find(so) != collected_decls.end()) {
 		a->var1 = collected_decls[so];
@@ -65,7 +65,7 @@ void var_replacer::visit(var_expr::Ptr a) {
 }
 
 void var_hoister::visit(decl_stmt::Ptr a) {
-	std::string so = get_apt_tag(a->decl_var, escaping_tags);
+	tracer::tag so = get_apt_tag(a->decl_var, escaping_tags);
 	if (decls_to_hoist.find(so) != decls_to_hoist.end()) {
 
 		// if the variable is of reference type, we need to convert it to a pointer

--- a/src/builder/builder.cpp
+++ b/src/builder/builder.cpp
@@ -2,7 +2,7 @@
 #include "builder/builder_context.h"
 #include "builder/dyn_var.h"
 #include "util/tracer.h"
-
+#include "builder/static_var.h"
 namespace builder {
 namespace options {
 bool track_members = false;
@@ -71,5 +71,8 @@ builder::builder(const var &a) {
 	}
 	push_to_sequence(block_expr);
 }
+
+static_var_base::~static_var_base() {}
+static_var_snapshot_base::~static_var_snapshot_base() {}
 
 } // namespace builder

--- a/src/util/var_finder.cpp
+++ b/src/util/var_finder.cpp
@@ -2,6 +2,7 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <map>
+#include <unordered_map>
 
 #ifdef RECOVER_VAR_NAMES
 #define UNW_LOCAL_ONLY
@@ -19,7 +20,7 @@
 #include <libdwarf/dwarf.h>
 #include <libdwarf/libdwarf.h>
 
-namespace util {
+namespace utils {
 
 // Default member separator is "_"
 // this can be set by callers if they want 
@@ -491,25 +492,25 @@ std::string find_variable_name(void *addr) {
 	return find_variable_from_this(addr);
 }
 
-} // namespace util
+} // namespace utils
 #else
-namespace util {
+namespace utils {
 std::string find_variable_name(void *addr) {
 	return "";
 }
-} // namespace util
+} // namespace utils
 #endif
 
-namespace util {
-static std::map<std::string, std::string> tag_var_name_map;
-std::string find_variable_name_cached(void *addr, std::string tag_string) {
-	if (tag_var_name_map.find(tag_string) != tag_var_name_map.end()) {
-		return tag_var_name_map[tag_string];
+namespace utils {
+static std::unordered_map<tracer::tag, std::string> tag_var_name_map;
+std::string find_variable_name_cached(void *addr, tracer::tag stag) {
+	if (tag_var_name_map.find(stag) != tag_var_name_map.end()) {
+		return tag_var_name_map[stag];
 	}
 
 	std::string ret = find_variable_name(addr);
 	if (ret != "")
-		tag_var_name_map[tag_string] = ret;
+		tag_var_name_map[stag] = ret;
 	return ret;
 }
-} // namespace util
+} // namespace utils


### PR DESCRIPTION
This change set adds a major feature which allows wrapping static_var around arbitrary types that have a copy constructor and == defined. This is required for wrapping STL types like vectors and maps into static_var. 

With this, we also deprecate using tag.stringify() as a unique representation of tag since some types cannot be stringified. All (unordered) maps and sets now directly use tag as an index. To support this a std::hash implementation has been added for tags. The objects that cannot be hashed are not included in the hash, which could also collisions, but that is okay since hashes are expected to be completely unique, the == operator does handle correctness. 

The hash implementation caches hashes as much as possible to avoid overheads and virtual dispatches. Finally, the snapshots that are part of the static tag are now heap allocated and shared using shared_ptr. 

TODO: add caching to static_var so that new snapshot isn't generated everytime if the object hasn't changed. 

Limitations: When aggregate types are wrapped in static_var, they don't automatically convert when members are accessed. So they still need to be accessed as static_var.val.member(). In this future this can be fixed by making static_var<T> inherit from T in case of aggregate types just like dyn_var. 

sample65 has been added to test this. 